### PR TITLE
remove un-needed middleware class

### DIFF
--- a/public_interface/settings.py
+++ b/public_interface/settings.py
@@ -97,7 +97,6 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'easy_pjax.middleware.UnpjaxMiddleware',
 )
 
 ROOT_URLCONF = 'public_interface.urls'


### PR DESCRIPTION
correts:
https://github.com/ucldc/public_interface/commit/4c4de3add8e4965d61d2f21802b98e1e19b26893#diff-fcca0951241ace1e4e9e8a9c850e0132R95

I mis-read:
https://github.com/nigma/django-easy-pjax/blob/db6ecbdadf9232858999b367a16a90fba3d7a3f3/README.rst#django-19

"easy_pjax.middleware.UnpjaxMiddleware" in example is not needed
for django 1.9 migration