### PR TITLE
Publishable exhibitions & intelligent 'Read full exhibition overview' link

### DIFF
--- a/app/scripts/calisphere.js
+++ b/app/scripts/calisphere.js
@@ -90,11 +90,12 @@ $(document).ready(function() {
     });
 
     $('.button__contact-owner').on('click', function() {
-      ga('send', 'event', 'buttons', 'contact', event.target.href, {
+      var url = $(this).attr('href');
+      ga('send', 'event', 'buttons', 'contact', url, {
         'transport': 'beacon',  // use navigator.sendBeacon
         // click captured and tracked, send the user along
         'hitCallback': function () {
-          document.location = event.target.href;
+          document.location = url;
         }
       });
       return false;

--- a/app/scripts/new-search.js
+++ b/app/scripts/new-search.js
@@ -101,7 +101,15 @@ var exhibitPage = Backbone.View.extend({
   },
 
   clientTruncate: function() {
-    $('.js-exhibit__overview').dotdotdot();
+    $('.js-exhibit__overview').dotdotdot({callback: function(isTruncated) {
+      if (isTruncated) {
+        $('#js-exhibit__overview').text('Read full exhibition overview.');
+      } else {
+        $('.js-exhibit__overview').css('height', 'auto');
+      }
+    }});
+    
+    // $('.js-exhibit__overview').dotdotdot();
   },
 
   initialize: function() {

--- a/exhibits/admin.py
+++ b/exhibits/admin.py
@@ -111,7 +111,7 @@ class HistoricalEssayAdmin(admin.ModelAdmin):
         ('About this Essay',        {'fields': [('byline', 'byline_render_as')], 'classes': ['collapse']}),
         ('Metadata',                {'fields': [('meta_description', 'meta_keywords')], 'classes': ['collapse']})
     ]
-    list_display = ('title', 'hero', 'hero_first', 'get_absolute_url', 'publish', 'slug')
+    list_display = ('publish', 'title', 'hero', 'hero_first', 'slug', 'get_absolute_url')
     prepopulated_fields = {'slug': ['title']}
     inlines = [HistoricalEssayItemInline]
 
@@ -125,7 +125,7 @@ class ExhibitAdmin(admin.ModelAdmin):
         ('Metadata',                {'fields': [('meta_description', 'meta_keywords')], 'classes': ['collapse']})
     ]
     inlines = [ExhibitItemInline, NotesItemInline, ThemeExhibitInline, HistoricalEssayExhibitInline, LessonPlanExhibitInline, BrowseTermGroupInline]
-    list_display = ('title', 'hero', 'hero_first', 'scraped_from', 'slug', 'get_absolute_url')
+    list_display = ('publish', 'title', 'hero', 'hero_first', 'slug', 'get_absolute_url')
     prepopulated_fields = {'slug': ['title']}
 
 
@@ -138,6 +138,7 @@ class LessonPlanAdmin(admin.ModelAdmin):
         ('Metadata',                {'fields': [('meta_description', 'meta_keywords')], 'classes': ['collapse']})
     ]
     prepopulated_fields = {'slug': ['title']}
+    list_display = ('publish', 'title', 'slug', 'get_absolute_url')
     inlines = [LessonPlanItemInline]
 
 class BrowseTermGroupAdmin(admin.ModelAdmin):
@@ -153,6 +154,7 @@ class ThemeAdmin(admin.ModelAdmin):
         ('Metadata',                {'fields': [('meta_description', 'meta_keywords')], 'classes': ['collapse']})
     ]
     inlines = [ExhibitThemeInline, HistoricalEssayThemeInline, LessonPlanThemeInline, BrowseTermGroupInline]
+    list_display = ('publish', 'title', 'hero', 'hero_first', 'slug', 'get_absolute_url')
     prepopulated_fields = {'slug': ['title']}
 
 

--- a/exhibits/admin.py
+++ b/exhibits/admin.py
@@ -111,7 +111,7 @@ class HistoricalEssayAdmin(admin.ModelAdmin):
         ('About this Essay',        {'fields': [('byline', 'byline_render_as')], 'classes': ['collapse']}),
         ('Metadata',                {'fields': [('meta_description', 'meta_keywords')], 'classes': ['collapse']})
     ]
-    list_display = ('publish', 'title', 'hero', 'hero_first', 'slug', 'get_absolute_url')
+    list_display = ('title', 'hero', 'hero_first', 'slug', 'get_absolute_url', 'publish')
     prepopulated_fields = {'slug': ['title']}
     inlines = [HistoricalEssayItemInline]
 
@@ -125,7 +125,7 @@ class ExhibitAdmin(admin.ModelAdmin):
         ('Metadata',                {'fields': [('meta_description', 'meta_keywords')], 'classes': ['collapse']})
     ]
     inlines = [ExhibitItemInline, NotesItemInline, ThemeExhibitInline, HistoricalEssayExhibitInline, LessonPlanExhibitInline, BrowseTermGroupInline]
-    list_display = ('publish', 'title', 'hero', 'hero_first', 'slug', 'get_absolute_url')
+    list_display = ('title', 'hero', 'hero_first', 'slug', 'get_absolute_url', 'publish')
     prepopulated_fields = {'slug': ['title']}
 
 
@@ -138,7 +138,7 @@ class LessonPlanAdmin(admin.ModelAdmin):
         ('Metadata',                {'fields': [('meta_description', 'meta_keywords')], 'classes': ['collapse']})
     ]
     prepopulated_fields = {'slug': ['title']}
-    list_display = ('publish', 'title', 'slug', 'get_absolute_url')
+    list_display = ('title', 'slug', 'get_absolute_url', 'publish')
     inlines = [LessonPlanItemInline]
 
 class BrowseTermGroupAdmin(admin.ModelAdmin):
@@ -154,7 +154,7 @@ class ThemeAdmin(admin.ModelAdmin):
         ('Metadata',                {'fields': [('meta_description', 'meta_keywords')], 'classes': ['collapse']})
     ]
     inlines = [ExhibitThemeInline, HistoricalEssayThemeInline, LessonPlanThemeInline, BrowseTermGroupInline]
-    list_display = ('publish', 'title', 'hero', 'hero_first', 'slug', 'get_absolute_url')
+    list_display = ('title', 'hero', 'hero_first', 'slug', 'get_absolute_url', 'publish')
     prepopulated_fields = {'slug': ['title']}
 
 

--- a/exhibits/models.py
+++ b/exhibits/models.py
@@ -57,6 +57,12 @@ class Exhibit(models.Model):
     def __str__(self):
         return self.title
 
+    def published_essays(self):
+        return self.historicalessayexhibit_set.filter(historicalEssay__publish=True)
+
+    def published_lessons(self):
+        return self.lessonplanexhibit_set.filter(lessonPlan__publish=True)
+
     def get_absolute_url(self):
         return reverse('exhibits:exhibitView', kwargs={'exhibit_id': self.id, 'exhibit_slug': self.slug})
 
@@ -143,6 +149,12 @@ class HistoricalEssay(models.Model):
     meta_description = models.CharField(max_length=255, blank=True)
     meta_keywords = models.CharField(max_length=255, blank=True)
         
+    def published_exhibits(self):
+        return self.historicalessayexhibit_set.filter(exhibit__publish=True)
+
+    def published_themes(self):
+        return self.historicalessaytheme_set.filter(theme__publish=True)
+
     def get_absolute_url(self):
         return reverse('exhibits:essayView', kwargs={'essay_id': self.id, 'essay_slug': self.slug})
 
@@ -216,6 +228,12 @@ class LessonPlan(models.Model):
     def __str__(self):
         return self.title
     
+    def published_themes(self):
+        return self.lessonplantheme_set.filter(theme__publish=True)
+
+    def published_exhibits(self):
+        return self.lessonplanexhibit_set.filter(exhibit__publish=True)
+
     def get_absolute_url(self):
         return reverse('for-teachers:lessonPlanView', kwargs={'lesson_id': self.id, 'lesson_slug': self.slug})
 
@@ -288,6 +306,15 @@ class Theme(models.Model):
         (JARDA, 'JARDA')
     )
     category = models.CharField(max_length=20, choices=CATEGORY_CHOICES, blank=True)
+
+    def published_essays(self):
+        return self.historicalessaytheme_set.filter(historicalEssay__publish=True)
+
+    def published_lessons(self):
+        return self.lessonplantheme_set.filter(lessonPlan__publish=True)
+
+    def published_exhibits(self):
+        return self.exhibittheme_set.filter(exhibit__publish=True)
 
     def get_absolute_url(self):
         return reverse('exhibits:themeView', kwargs={'theme_id': self.id, 'theme_slug': self.slug})

--- a/exhibits/models.py
+++ b/exhibits/models.py
@@ -31,6 +31,13 @@ RENDERING_OPTIONS = (
 #     def __str__(self):
 #         return self.item_id
 
+class PublishedExhibitManager(models.Manager):
+    def get_queryset(self):
+        if settings.EXHIBIT_PREVIEW:
+            return super(PublishedExhibitManager, self).get_queryset()
+        else:
+            return super(PublishedExhibitManager, self).get_queryset().filter(publish=True)
+
 @python_2_unicode_compatible
 class Exhibit(models.Model):
     title = models.CharField(max_length=512)
@@ -54,14 +61,28 @@ class Exhibit(models.Model):
     meta_description = models.CharField(max_length=255, blank=True)
     meta_keywords = models.CharField(max_length=255, blank=True)
     
+    objects = PublishedExhibitManager()
+
     def __str__(self):
         return self.title
 
+    def published_themes(self):
+        if settings.EXHIBIT_PREVIEW:
+            return self.exhibittheme_set
+        else:
+            return self.exhibittheme_set.filter(theme__publish=True)
+
     def published_essays(self):
-        return self.historicalessayexhibit_set.filter(historicalEssay__publish=True)
+        if settings.EXHIBIT_PREVIEW:
+            return self.historicalessayexhibit_set
+        else:
+            return self.historicalessayexhibit_set.filter(historicalEssay__publish=True)
 
     def published_lessons(self):
-        return self.lessonplanexhibit_set.filter(lessonPlan__publish=True)
+        if settings.EXHIBIT_PREVIEW:
+            return self.lessonplanexhibit_set
+        else:
+            return self.lessonplanexhibit_set.filter(lessonPlan__publish=True)
 
     def get_absolute_url(self):
         return reverse('exhibits:exhibitView', kwargs={'exhibit_id': self.id, 'exhibit_slug': self.slug})
@@ -124,6 +145,14 @@ class Exhibit(models.Model):
                     super(Exhibit, self).save(update_fields=[s3field])
                     self._meta.get_field(s3field).upload_to = upload_to
 
+
+class PublishedHistoricalEssayManager(models.Manager):
+    def get_queryset(self):
+        if settings.EXHIBIT_PREVIEW:
+            return super(PublishedHistoricalEssayManager, self).get_queryset()
+        else:
+            return super(PublishedHistoricalEssayManager, self).get_queryset().filter(publish=True)
+
 @python_2_unicode_compatible
 class HistoricalEssay(models.Model):
     title = models.CharField(max_length=200)
@@ -148,12 +177,20 @@ class HistoricalEssay(models.Model):
     color = models.CharField(max_length=20, blank=True, help_text="Please provide color in <code>#xxx</code>, <code>#xxxxxx</code>, <code>rgb(xxx,xxx,xxx)</code>, or <code>rgba(xxx,xxx,xxx,x.x)</code> formats.")
     meta_description = models.CharField(max_length=255, blank=True)
     meta_keywords = models.CharField(max_length=255, blank=True)
+
+    objects = PublishedHistoricalEssayManager()
         
     def published_exhibits(self):
-        return self.historicalessayexhibit_set.filter(exhibit__publish=True)
+        if settings.EXHIBIT_PREVIEW:
+            return self.historicalessayexhibit_set
+        else:
+            return self.historicalessayexhibit_set.filter(exhibit__publish=True)
 
     def published_themes(self):
-        return self.historicalessaytheme_set.filter(theme__publish=True)
+        if settings.EXHIBIT_PREVIEW:
+            return self.historicalessaytheme_set
+        else:
+            return self.historicalessaytheme_set.filter(theme__publish=True)
 
     def get_absolute_url(self):
         return reverse('exhibits:essayView', kwargs={'essay_id': self.id, 'essay_slug': self.slug})
@@ -204,6 +241,14 @@ class HistoricalEssay(models.Model):
     def __str__(self):
         return self.title
 
+
+class PublishedLessonPlanManager(models.Manager):
+    def get_queryset(self):
+        if settings.EXHIBIT_PREVIEW:
+            return super(PublishedLessonPlanManager, self).get_queryset()
+        else:
+            return super(PublishedLessonPlanManager, self).get_queryset().filter(publish=True)
+
 @python_2_unicode_compatible
 class LessonPlan(models.Model):
     title = models.CharField(max_length=200)
@@ -224,15 +269,23 @@ class LessonPlan(models.Model):
     publish = models.BooleanField(verbose_name='Ready for publication?', default=False)
     meta_description = models.CharField(max_length=255, blank=True)
     meta_keywords = models.CharField(max_length=255, blank=True)
-    
+
+    objects = PublishedLessonPlanManager()
+
     def __str__(self):
         return self.title
     
     def published_themes(self):
-        return self.lessonplantheme_set.filter(theme__publish=True)
+        if settings.EXHIBIT_PREVIEW:
+            return self.lessonplantheme_set
+        else:
+            return self.lessonplantheme_set.filter(theme__publish=True)
 
     def published_exhibits(self):
-        return self.lessonplanexhibit_set.filter(exhibit__publish=True)
+        if settings.EXHIBIT_PREVIEW:
+            return self.lessonplanexhibit_set
+        else:
+            return self.lessonplanexhibit_set.filter(exhibit__publish=True)
 
     def get_absolute_url(self):
         return reverse('for-teachers:lessonPlanView', kwargs={'lesson_id': self.id, 'lesson_slug': self.slug})
@@ -276,6 +329,14 @@ class LessonPlan(models.Model):
                     super(LessonPlan, self).save(update_fields=[s3field])
                     self._meta.get_field(s3field).upload_to = upload_to
 
+
+class PublishedThemeManager(models.Manager):
+    def get_queryset(self):
+        if settings.EXHIBIT_PREVIEW:
+            return super(PublishedThemeManager, self).get_queryset()
+        else:
+            return super(PublishedThemeManager, self).get_queryset().filter(publish=True)
+
 @python_2_unicode_compatible
 class Theme(models.Model): 
     title = models.CharField(max_length=200)
@@ -296,7 +357,9 @@ class Theme(models.Model):
     publish = models.BooleanField(verbose_name='Ready for publication?', default=False)
     meta_description = models.CharField(max_length=255, blank=True)
     meta_keywords = models.CharField(max_length=255, blank=True)
-    
+
+    objects = PublishedThemeManager()
+
     CALHISTORY = 'cal-history'
     CALCULTURES = 'cal-cultures'
     JARDA = 'jarda'
@@ -308,13 +371,22 @@ class Theme(models.Model):
     category = models.CharField(max_length=20, choices=CATEGORY_CHOICES, blank=True)
 
     def published_essays(self):
-        return self.historicalessaytheme_set.filter(historicalEssay__publish=True)
+        if settings.EXHIBIT_PREVIEW:
+            return self.historicalessaytheme_set
+        else:
+            return self.historicalessaytheme_set.filter(historicalEssay__publish=True)
 
     def published_lessons(self):
-        return self.lessonplantheme_set.filter(lessonPlan__publish=True)
+        if settings.EXHIBIT_PREVIEW:
+            return self.lessonplantheme_set
+        else:
+            return self.lessonplantheme_set.filter(lessonPlan__publish=True)
 
     def published_exhibits(self):
-        return self.exhibittheme_set.filter(exhibit__publish=True)
+        if settings.EXHIBIT_PREVIEW:
+            return self.exhibittheme_set
+        else:
+            return self.exhibittheme_set.filter(exhibit__publish=True)
 
     def get_absolute_url(self):
         return reverse('exhibits:themeView', kwargs={'theme_id': self.id, 'theme_slug': self.slug})

--- a/exhibits/templates/exhibits/calCultures.html
+++ b/exhibits/templates/exhibits/calCultures.html
@@ -46,6 +46,7 @@
   </div>
   
   <div>
+    {% if historical_essays|length > 0 %}
     <h3 id="historicalEssays">Read related essays ({{ historical_essays|length }}):</h3>
     <div class="row js-related-carousel exhibit__related-carousel">
       {% for he in historical_essays %}
@@ -61,7 +62,9 @@
         </div>
       {% endfor %}
     </div>
+    {% endif %}
 
+    {% if lesson_plans|length > 0 %}
     <h3>Just for teachers: lesson plans ({{ lesson_plans|length }}):</h3>
     <div class="row js-related-carousel exhibit__related-carousel">
       {% for lp in lesson_plans %}
@@ -77,6 +80,7 @@
         </div>
       {% endfor %}
     </div>
+    {% endif %}
   </div>
 
   <div class="row">

--- a/exhibits/templates/exhibits/essayView.html
+++ b/exhibits/templates/exhibits/essayView.html
@@ -35,18 +35,18 @@
             {% include "exhibits/render_as.html" with render_as=essay.go_further_render_as text=essay.go_further truncate=False container_class="" %}
           </div>
         {% endif %}
-        {% if essay.historicalessayexhibit_set.all|length > 0 %}
+        {% if essay.published_exhibits.all|length > 0 %}
           <div class="essay__note">
             <h3>Related exhibitions</h3>
-            {% for hee in essay.historicalessayexhibit_set.all %}
+            {% for hee in essay.published_exhibits.all %}
               <a href="{{ hee.exhibit.get_absolute_url }}" data-pjax="js-pageContent">{{ hee.exhibit }}</a><br/>
             {% endfor %}
           </div>
         {% endif %}
-        {% if essay.historicalessaytheme_set.all|length > 0 %}
+        {% if essay.published_themes.all|length > 0 %}
           <div class="essay__note">
             <h3>Related themes</h3>
-            {% for het in essay.historicalessaytheme_set.all %}
+            {% for het in essay.published_themes.all %}
               <a href="{{ het.theme.get_absolute_url }}" data-pjax="js-pageContent">{{ het.theme }}</a><br/>
             {% endfor %}
           </div>

--- a/exhibits/templates/exhibits/exhibitRandomExplore.html
+++ b/exhibits/templates/exhibits/exhibitRandomExplore.html
@@ -37,7 +37,7 @@
                   <div class="theme__lockup--horizontal-color" style="background-color: {{ entry.color }}"></div>
                   <div class="theme__lockup--horizontal-title">
                     {{ entry.title }}
-                    <div class="theme__lockup--horizontal-exhibit-count">{{ entry.published_exhibits|length }} exhibition{{ entry.published_exhibits|pluralize }}</div>
+                    <div class="theme__lockup--horizontal-exhibit-count">{{ entry.published_exhibits.all|length }} exhibition{{ entry.published_exhibits.all|pluralize }}</div>
                   </div>
                 </div>
               </div>

--- a/exhibits/templates/exhibits/exhibitRandomExplore.html
+++ b/exhibits/templates/exhibits/exhibitRandomExplore.html
@@ -37,7 +37,7 @@
                   <div class="theme__lockup--horizontal-color" style="background-color: {{ entry.color }}"></div>
                   <div class="theme__lockup--horizontal-title">
                     {{ entry.title }}
-                    <div class="theme__lockup--horizontal-exhibit-count">{{ entry.exhibittheme_set.all|length }} exhibitions</div>
+                    <div class="theme__lockup--horizontal-exhibit-count">{{ entry.published_exhibits|length }} exhibition{{ entry.published_exhibits|pluralize }}</div>
                   </div>
                 </div>
               </div>

--- a/exhibits/templates/exhibits/exhibitView.html
+++ b/exhibits/templates/exhibits/exhibitView.html
@@ -77,7 +77,7 @@
   </div>
   {% endif %}
 
-  {% if relatedExhibitsByTheme|length > 0 or exhibit.historicalessayexhibit_set.all|length > 0 or exhibit.lessonplanexhibit_set.all|length > 0 %}
+  {% if relatedExhibitsByTheme|length > 0 or exhibit.published_essays.all|length > 0 or exhibit.published_lessons.all|length > 0 %}
   <div class="exhibit__related-materials">
   {% endif %}
   {% if relatedExhibitsByTheme|length > 0 %}
@@ -105,10 +105,10 @@
     {% endfor %}
   {% endif %}
     
-  {% if exhibit.historicalessayexhibit_set.all|length > 0 %}
-    <h3>Read related essays ({{ exhibit.historicalessayexhibit_set.all|length }}):</h3>
+  {% if exhibit.published_essays.all|length > 0 %}
+    <h3>Read related essays ({{ exhibit.published_essays.all|length }}):</h3>
     <div class="row js-related-carousel exhibit__related-carousel">
-      {% for hee in exhibit.historicalessayexhibit_set.all %}
+      {% for hee in exhibit.published_essays.all %}
         <div class="col-xs-2 col-md-3">
           <a href="{{ hee.historicalEssay.get_absolute_url }}" data-pjax="js-pageContent">
             <div class="exhibit__essay-lockup">
@@ -123,10 +123,10 @@
     </div>
   {% endif %}
 
-  {% if exhibit.lessonplanexhibit_set.all|length > 0 %}
-    <h3>Just for teachers: lesson plans ({{ exhibit.lessonplanexhibit_set.all|length }}):</h3>
+  {% if exhibit.published_lessons.all|length > 0 %}
+    <h3>Just for teachers: lesson plans ({{ exhibit.published_lessons.all|length }}):</h3>
     <div class="row js-related-carousel exhibit__related-carousel">
-      {% for lpe in exhibit.lessonplanexhibit_set.all %}
+      {% for lpe in exhibit.published_lessons.all %}
         <div class="col-xs-2 col-md-3">
           <a href="{{ lpe.lessonPlan.get_absolute_url }}" data-pjax="js-pageContent">
             <div class="exhibit__lesson-lockup">
@@ -141,7 +141,7 @@
     </div>
   {% endif %}
   
-  {% if relatedExhibitsByTheme|length > 0 or exhibit.historicalessayexhibit_set.all|length > 0 or exhibit.lessonplanexhibit_set.all|length > 0 %}
+  {% if relatedExhibitsByTheme|length > 0 or exhibit.published_essays.all|length > 0 or exhibit.published_lessons.all|length > 0 %}
   </div>
   {% endif %}
 

--- a/exhibits/templates/exhibits/item_content.html
+++ b/exhibits/templates/exhibits/item_content.html
@@ -10,7 +10,7 @@
     </div>
   </a>
   {% else %}
-  <div class="js-exhibit-item exhibit__modal-arrow">
+  <div class="exhibit__modal-arrow">
     <div class="exhibit__modal-arrow-position">
       <i class="fa fa-angle-left" style="font-size: 70px; opacity: 0;"></i>
     </div>
@@ -165,7 +165,7 @@
     </div>
   </a>
   {% else %}
-  <div class="js-exhibit-item exhibit__modal-arrow">
+  <div class="exhibit__modal-arrow">
     <div class="exhibit__modal-arrow-position">
       <i class="fa fa-angle-left" style="font-size: 70px; opacity: 0;"></i>
     </div>

--- a/exhibits/templates/exhibits/lessonPlanView.html
+++ b/exhibits/templates/exhibits/lessonPlanView.html
@@ -47,8 +47,8 @@
         <div class="lessonplan__info-box">
           <b>Grade Level Recommendation:</b><br>
           {{ lessonPlan.grade_level }}<br><br>
-          <b>Relates to:</b>
-          {% for lpt in lessonPlan.lessonplantheme_set.all %}{% if forloop.counter != 1 %}, {% endif %}<a href="{{ lpt.theme.get_absolute_url }}" data-pjax="js-pageContent">{{ lpt.theme }}</a>{% endfor %}
+          {% if lessonPlan.published_themes.all|length > 0 %}<b>Relates to:</b>{% endif %}
+          {% for lpt in lessonPlan.published_themes.all %}{% if forloop.counter != 1 %}, {% endif %}<a href="{{ lpt.theme.get_absolute_url }}" data-pjax="js-pageContent">{{ lpt.theme }}</a>{% endfor %}
         </div>
       </div>
     </div>
@@ -68,12 +68,12 @@
   </div>
   {% endif %}
   
-  {% if lessonPlan.lessonplanexhibit_set.all|length > 0 %}
+  {% if lessonPlan.published_exhibits.all|length > 0 %}
   <div class="exhibit__related-materials">
-    <h3>Explore exhibitions related to "{{ lessonPlan.title }}" ({{ lessonPlan.lessonplanexhibit_set.all|length }}):</h3>
+    <h3>Explore exhibitions related to "{{ lessonPlan.title }}" ({{ lessonPlan.published_exhibits.all|length }}):</h3>
     <div class="exhibit__items" style="padding: 25px 25px 0 25px; margin-top: 0;">
       <div class="row js-related-carousel exhibit__related-carousel">
-        {% for lpe in lessonPlan.lessonplanexhibit_set.all %}
+        {% for lpe in lessonPlan.published_exhibits.all %}
           <div class="col-xs-2 col-md-3">
             <a href="{{ lpe.exhibit.get_absolute_url }}" data-pjax="js-pageContent">
               <div class="exhibit__lockup--med">

--- a/exhibits/templates/exhibits/render_as.html
+++ b/exhibits/templates/exhibits/render_as.html
@@ -15,7 +15,7 @@
       {{ text }}
     </div>
   {% endif %}
-  <a href="javascript: void(0)" id="{{ container_class }}">Read full exhibition overview</a>
+  <a href="javascript: void(0)" id="{{ container_class }}"></a>
 {% else %}
   {% if render_as == 'H' %}
     <div class="{{ container_class }}">

--- a/exhibits/templates/exhibits/themeView.html
+++ b/exhibits/templates/exhibits/themeView.html
@@ -47,10 +47,10 @@
   </div>
   
   <div>
-  {% if theme.historicalessaytheme_set.all|length > 0 %}
-    <h3>Read related essays ({{ theme.historicalessaytheme_set.all|length }}):</h3>
+  {% if theme.published_essays.all|length > 0 %}
+    <h3>Read related essays ({{ theme.published_essays.all|length }}):</h3>
     <div class="row js-related-carousel exhibit__related-carousel">
-      {% for het in theme.historicalessaytheme_set.all %}
+      {% for het in theme.published_essays.all %}
         <div class="col-xs-2 col-md-3">
           <a href="{{ het.historicalEssay.get_absolute_url }}" data-pjax="js-pageContent">
             <div class="exhibit__essay-lockup">
@@ -65,10 +65,10 @@
     </div>
   {% endif %}
 
-  {% if theme.lessonplantheme_set.all|length > 0 %}
-    <h3>Just for teachers: lesson plans ({{ theme.lessonplantheme_set.all|length }}):</h3>
+  {% if theme.published_lessons.all|length > 0 %}
+    <h3>Just for teachers: lesson plans ({{ theme.published_lessons.all|length }}):</h3>
     <div class="row js-related-carousel exhibit__related-carousel">
-      {% for lpt in theme.lessonplantheme_set.all %}
+      {% for lpt in theme.published_lessons.all %}
         <div class="col-xs-2 col-md-3">
           <a href="{{ lpt.lessonPlan.get_absolute_url }}" data-pjax="js-pageContent">
             <div class="exhibit__lesson-lockup">

--- a/exhibits/views.py
+++ b/exhibits/views.py
@@ -1,21 +1,22 @@
 from __future__ import unicode_literals
 
 from django.shortcuts import get_object_or_404, render, redirect
-from django.http import HttpResponse, Http404
+from django.http import HttpResponse
 from django.core.exceptions import ObjectDoesNotExist
 from exhibits.models import *
 from itertools import chain
+from django.conf import settings
 import random
 
 def calCultures(request):
-    california_cultures = Theme.objects.filter(title__icontains='California Cultures', publish=True).order_by('title')
+    california_cultures = Theme.objects.filter(title__icontains='California Cultures').order_by('title')
 
-    unique_historical_essays = HistoricalEssay.objects.filter(historicalessaytheme__theme__in=california_cultures, publish=True).values_list('title', 'id').distinct()
+    unique_historical_essays = HistoricalEssay.objects.filter(historicalessaytheme__theme__in=california_cultures).values_list('title', 'id').distinct()
     historical_essays = []
     for (title, key) in unique_historical_essays:
         historical_essays.append(HistoricalEssay.objects.get(pk=key))
 
-    unique_lesson_plans = LessonPlan.objects.filter(lessonplantheme__theme__in=california_cultures, publish=True).values_list('title', 'id').distinct()
+    unique_lesson_plans = LessonPlan.objects.filter(lessonplantheme__theme__in=california_cultures).values_list('title', 'id').distinct()
     lesson_plans = []
     for (title, key) in unique_lesson_plans:
         lesson_plans.append(LessonPlan.objects.get(pk=key))
@@ -27,8 +28,8 @@ def calCultures(request):
     })
 
 def exhibitRandom(request):
-    exhibits = Exhibit.objects.filter(publish=True)
-    themes = Theme.objects.filter(publish=True)
+    exhibits = Exhibit.objects.all()
+    themes = Theme.objects.all()
     exhibit_theme_list = list(chain(exhibits, themes))
     random.shuffle(exhibit_theme_list)
 
@@ -77,29 +78,34 @@ def exhibitRandom(request):
 
 def exhibitSearch(request):
     if request.method == 'GET' and len(request.GET.getlist('title')) > 0:
-        exhibits = Exhibit.objects.filter(title__icontains=request.GET['title'], publish=True).order_by('title')
+        exhibits = Exhibit.objects.filter(title__icontains=request.GET['title']).order_by('title')
         return render(request, 'exhibits/exhibitSearch.html', {'searchTerm': request.GET['title'], 'exhibits': exhibits})
     else: 
-        exhibits = Exhibit.objects.all().filter(publish=True).order_by('title')
+        exhibits = Exhibit.objects.all().order_by('title')
         return render(request, 'exhibits/exhibitSearch.html', {'searchTerm': '', 'exhibits': exhibits})
 
 def exhibitDirectory(request, category='search'):
     if category in list(category for (category, display) in Theme.CATEGORY_CHOICES):
-        themes = Theme.objects.filter(category=category, publish=True).order_by('sort_title')
+        themes = Theme.objects.filter(category=category).order_by('sort_title')
         collated = []
         for theme in themes:
-            exhibits = Exhibit.objects.filter(exhibittheme__theme=theme, publish=True)
+            exhibits = Exhibit.objects.filter(exhibittheme__theme=theme)
             collated.append((theme, exhibits))
         return render(request, 'exhibits/exhibitDirectory.html', {'themes': collated, 'categories': Theme.CATEGORY_CHOICES, 'selected': category})
         
     if category == 'all': 
-        exhibits = Exhibit.objects.all().filter(publish=True).order_by('title')
+        exhibits = Exhibit.objects.all().order_by('title')
     if category == 'uncategorized':
 
-        # if exhibit's theme is null OR if exhibit's theme is unpublished, but the exhibit is published
-        exhibitsWithNoTheme = Exhibit.objects.filter(exhibittheme__isnull=True, publish=True)
-        exhibitsWithUnpublishedTheme = Exhibit.objects.filter(exhibittheme__theme__publish=False, publish=True)
-        exhibits = exhibitsWithNoTheme | exhibitsWithUnpublishedTheme
+        # if previewing exhibits, only show in uncategorized those exhibits which are not hooked up to a theme
+        if settings.EXHIBIT_PREVIEW:
+            exhibits = Exhibit.objects.filter(exhibittheme__isnull=True)
+        # if showing exhibits on production, show both exhibits which are not hooked up to a theme
+        # AND exhibits which are hooked up to a theme, but the theme is unpublished.
+        else:
+            exhibitsWithNoTheme = Exhibit.objects.filter(exhibittheme__isnull=True)
+            exhibitsWithUnpublishedTheme = Exhibit.objects.filter(exhibittheme__theme__publish=False)
+            exhibits = exhibitsWithNoTheme | exhibitsWithUnpublishedTheme
 
     return render(request, 'exhibits/exhibitDirectory.html', {'themes': [{'', exhibits}], 'categories': Theme.CATEGORY_CHOICES, 'selected': category})
 
@@ -110,8 +116,8 @@ def themeDirectory(request):
     return render(request, 'exhibits/themeDirectory.html', {'jarda': jarda, 'california_cultures': california_cultures, 'california_history': california_history})
 
 def lessonPlanDirectory(request):
-    lessonPlans = LessonPlan.objects.filter(publish=True)
-    historicalEssays = HistoricalEssay.objects.filter(publish=True)
+    lessonPlans = LessonPlan.objects.all()
+    historicalEssays = HistoricalEssay.objects.all()
     return render(request, 'exhibits/for-teachers.html', {'lessonPlans': lessonPlans, 'historicalEssays': historicalEssays})
 
 def itemView(request, exhibit_id, item_id):
@@ -129,11 +135,13 @@ def itemView(request, exhibit_id, item_id):
     if fromExhibitPage:
         return render(request, 'exhibits/itemView.html', {'exhibitItem': exhibitItem, 'nextItem': nextItem, 'prevItem': prevItem})
     else:
-        exhibit = get_object_or_404(Exhibit, pk=exhibit_id, publish=True)
+        exhibit = get_object_or_404(Exhibit, pk=exhibit_id)
         exhibitItems = exhibit.exhibititem_set.all().order_by('order')
         exhibitListing = []
-        for theme in exhibit.exhibittheme_set.all():
-            exhibitListing.append((theme.theme, theme.theme.exhibittheme_set.exclude(exhibit=exhibit).order_by('order')))
+        for theme in exhibit.published_themes().all():
+            exhibits = theme.theme.published_exhibits().exclude(exhibit=exhibit).order_by('order')
+            if exhibits.count() > 0:
+                exhibitListing.append((theme.theme, exhibits))
         return render(request, 'exhibits/itemView.html',
         {'exhibit': exhibit, 'q': '', 'exhibitItems': exhibitItems, 'relatedExhibitsByTheme': exhibitListing, 'exhibitItem': exhibitItem, 'nextItem': nextItem, 'prevItem': prevItem})
 
@@ -152,7 +160,7 @@ def lessonPlanItemView(request, lesson_id, item_id):
     if fromLessonPage:
         return render(request, 'exhibits/lessonItemView.html', {'exhibitItem': exhibitItem, 'nextItem': nextItem, 'prevItem': prevItem})
     else:
-        lesson = get_object_or_404(LessonPlan, pk=lesson_id, publish=True)
+        lesson = get_object_or_404(LessonPlan, pk=lesson_id)
         exhibitItems = lesson.exhibititem_set.all().order_by('lesson_plan_order')
         return render(request, 'exhibits/lessonItemView.html',
         {'lessonPlan': lesson, 'q': '', 'exhibitItems': exhibitItems, 'exhibitItem': exhibitItem, 'nextItem': nextItem, 'prevItem': prevItem})
@@ -165,13 +173,11 @@ def exhibitView(request, exhibit_id, exhibit_slug):
     exhibit = get_object_or_404(Exhibit, pk=exhibit_id)
     if exhibit_slug != exhibit.slug:
         return redirect(exhibit)
-    if not exhibit.publish:
-        raise Http404("Exhibit is unpublished");
 
     exhibitItems = exhibit.exhibititem_set.all().order_by('order')
     exhibitListing = []
-    for theme in exhibit.exhibittheme_set.filter(theme__publish=True).all():
-        exhibits = theme.theme.exhibittheme_set.exclude(exhibit=exhibit).filter(exhibit__publish=True).order_by('order')
+    for theme in exhibit.published_themes().all():
+        exhibits = theme.theme.published_exhibits().exclude(exhibit=exhibit).order_by('order')
         if exhibits.count() > 0:
             exhibitListing.append((theme.theme, exhibits))
 
@@ -182,8 +188,6 @@ def essayView(request, essay_id, essay_slug):
     essay = get_object_or_404(HistoricalEssay, pk=essay_id)
     if essay_slug != essay.slug:
         return redirect(essay)
-    if not essay.publish:
-        raise Http404("Essay is unpublished");
 
     return render(request, 'exhibits/essayView.html', {'essay': essay, 'q': ''})
 
@@ -191,10 +195,8 @@ def themeView(request, theme_id, theme_slug):
     theme = get_object_or_404(Theme, pk=theme_id)
     if theme_slug != theme.slug:
         return redirect(theme)
-    if not theme.publish:
-        raise Http404("Theme is unpublished");
 
-    exhibitListing = theme.exhibittheme_set.filter(exhibit__publish=True).order_by('order')
+    exhibitListing = theme.published_exhibits().all().order_by('order')
     return render(request, 'exhibits/themeView.html', {'theme': theme, 'relatedExhibits': exhibitListing})
 
 def lessonPlanView(request, lesson_id, lesson_slug):
@@ -205,13 +207,11 @@ def lessonPlanView(request, lesson_id, lesson_slug):
     lesson = get_object_or_404(LessonPlan, pk=lesson_id)
     if lesson_slug != lesson.slug:
         return redirect(lesson)
-    if not lesson.publish:
-        raise Http404("Lesson plan is unpublished");
 
     exhibitItems = lesson.exhibititem_set.all().order_by('lesson_plan_order')
     
     relatedThemes = []
-    for theme in lesson.lessonplantheme_set.filter(theme__publish=True):
-        relatedThemes.append((theme.theme, theme.theme.lessonplantheme_set.exclude(lessonPlan=lesson)))
+    for theme in lesson.published_themes().all():
+        relatedThemes.append((theme.theme, theme.theme.published_lessons().exclude(lessonPlan=lesson)))
     
     return render(request, 'exhibits/lessonPlanView.html', {'lessonPlan': lesson, 'q': '', 'exhibitItems': exhibitItems, 'relatedThemes': relatedThemes})

--- a/public_interface/settings.py
+++ b/public_interface/settings.py
@@ -66,6 +66,10 @@ DEBUG = bool(os.environ.get('UCLDC_DEBUG'))  # <-- this is django's debug
 UCLDC_DEVEL = bool(os.environ.get('UCLDC_DEVEL'))
 #<-- this has to do with css via devMode
 
+# When EXHIBIT_PREVIEW = False, show only exhibits, themes, lesson plans, and essays marked 'published'
+# When EXHIBIT_PREVIEW = True, show ALL exhibits, themes, lesson plans, and essays
+EXHIBIT_PREVIEW = os.environ.get('UCLDC_EXHIBIT_PREVIEW') in ['True', 'true', '1']
+
 ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', '*').split(',')
 
 SITE_ID = 1

--- a/public_interface/settings.py
+++ b/public_interface/settings.py
@@ -68,7 +68,7 @@ UCLDC_DEVEL = bool(os.environ.get('UCLDC_DEVEL'))
 
 # When EXHIBIT_PREVIEW = False, show only exhibits, themes, lesson plans, and essays marked 'published'
 # When EXHIBIT_PREVIEW = True, show ALL exhibits, themes, lesson plans, and essays
-EXHIBIT_PREVIEW = os.environ.get('UCLDC_EXHIBIT_PREVIEW') in ['True', 'true', '1']
+EXHIBIT_PREVIEW = bool(os.environ.get('UCLDC_EXHIBIT_PREVIEW'))
 
 ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', '*').split(',')
 


### PR DESCRIPTION
Mostly this is a change to the exhibit models, views, and templates. 

Models.py:
- The `QueryManager` for `Theme`, `LessonPlan`, `Exhibit`, and `HistoricalEssay` is set to the `Published<Model>Manager`, which looks at the `settings.EXHIBIT_PREVIEW` flag to determine the default queryset to return. Calls like `Exhibit.objects.all()` or `Exhibit.objects.get()` or `get_object_or_404(Exhibit, pk=)` return only a subset of the default queryset.
- Retrieving items across a foreign key relation uses a `RelatedManager`, not the `QueryManager` defined above. Instead of creating a new `RelatedManager` which overwrites the default (as I did for the `QueryManager`), I augmented each of the models with a `published_<model>` method for each relevant foreign-key relationship which checks the `settings.EXHIBIT_PREVIEW` flag to determine if it should return only the published related items, or the full set of related items. 

Views.py & Templates:
- Changed calls across foreign key relations to use the `published_<model>` method. 

new-search.js & render_as.html:
- 'Read full exhibition overview.' no longer appears by default, but only when the exhibition overview actually gets truncated. The change to new-search.js has already been duplicated into the appropriate place in the back-button refactor and can be discarded when merging. 