### PR TITLE
django-positions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ six==1.10.0
 requests==2.11.1
 whitenoise==2.0.6
 wsgiref==0.1.2
-django-positions==0.5.3
+# django-positions==0.5.3
+https://github.com/amywieliczka/django-positions/archive/multi-collection-delete-issue.zip#egg=django-positions
 markdown==2.6.5
 https://github.com/ucldc/md5s3stash/archive/master.zip#egg=md5s3stash
 django-redis==4.4.3


### PR DESCRIPTION
Exhibit Items have 3 position fields: 

```python
class ExhibitItem(models.Model):
    order = PositionField(collection='exhibit')
    lesson_plan_order = PositionField(collection='lesson_plan')
    historical_essay_order = PositionField(collection='historical_essay')
```

When an ExhibitItem is deleted, each of these fields have to be updated, with respect to their respective `collection`s. django-positions assumed a model would only ever have one `PositionField`, pertaining to one `collection`. 