### PR TITLE
Increased number of images initially loaded for complex carousel

### DIFF
--- a/app/scripts/ComplexCarouselView.js
+++ b/app/scripts/ComplexCarouselView.js
@@ -13,8 +13,8 @@ var ComplexCarouselView = Backbone.View.extend({
     infinite: false,
     speed: 300,
     variableWidth: true,
-    slidesToShow: 8,
-    slidesToScroll: 8,
+    slidesToShow: 15,
+    slidesToScroll: 15,
     lazyLoad: 'ondemand'
   },
 


### PR DESCRIPTION
Fixes issue with Nightingale diaries where the thumbs are skinny so on desktop the carousel doesn't fill up all the way. 