### PR TITLE
works with python 2 and python 3

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -334,7 +334,14 @@ module.exports = function (grunt) {
             'images/{,*/}*.webp',
             '{,*/}*.html',
             'styles/{,*/}*.*',
-            'fonts/{,*/}*.*'
+            'fonts/{,*/}*.*',
+            'scripts/ComplexCarouselView.js',
+            'scripts/ContactOwnerFormView.js',
+            'scripts/ExhibitPageView.js',
+            'scripts/FacetFormView.js',
+            'scripts/GlobalSearchFormView.js',
+            'scripts/ItemView.js',
+            'scripts/QueryManager.js'
           ]
         }, {
           src: 'node_modules/apache-server-configs/dist/.htaccess',

--- a/calisphere/__init__.py
+++ b/calisphere/__init__.py
@@ -13,11 +13,14 @@ from django.template.defaulttags import URLNode
 # http://stackoverflow.com/a/20009830/1763984
 
 old_render = URLNode.render
+
+
 def new_render(cls, context):
     """ Override existing url method to use pluses instead of spaces
     """
     return old_render(cls, context).replace("%3A", ":")
-URLNode.render = new_render
 
+
+URLNode.render = new_render
 
 default_app_config = 'calisphere.apps.CalisphereAppConfig'

--- a/calisphere/apps.py
+++ b/calisphere/apps.py
@@ -1,9 +1,11 @@
 from django.apps import AppConfig
 from calisphere.registry_data import RegistryManager
 
+
 class CalisphereAppConfig(AppConfig):
     # http://stackoverflow.com/a/16111968/1763984
     name = 'calisphere'
     verbose_name = name
+
     def ready(self):
         self.registry = RegistryManager()

--- a/calisphere/cache_retry.py
+++ b/calisphere/cache_retry.py
@@ -72,14 +72,14 @@ def SOLR(**params):
     for key, value in facet_counts.get('facet_fields', {}).iteritems():
         # Make facet fields match edsu with grouper recipe
         facet_counts['facet_fields'][key] = dict(
-            itertools.izip_longest(
-                *[iter(value)] * 2, fillvalue=""))
+            itertools.izip_longest(*[iter(value)] * 2, fillvalue=""))
 
-    return SolrResults(results['response']['docs'],
-                       results['responseHeader'],
-                       results['response']['numFound'],
-                       facet_counts,
-                       results.get('nextCursorMark'), )
+    return SolrResults(
+        results['response']['docs'],
+        results['responseHeader'],
+        results['response']['numFound'],
+        facet_counts,
+        results.get('nextCursorMark'), )
 
 
 # create a hash for a cache key
@@ -142,7 +142,8 @@ def SOLR_raw(**kwargs):
         for key, value in kwargs.items():
             key = key.replace('_', '.')
             query.update({key: value})
-        res = requests.get(solr_url, headers=solr_auth, params=query, verify=False)
+        res = requests.get(
+            solr_url, headers=solr_auth, params=query, verify=False)
         res.raise_for_status()
         sr = res.content
         cache.set(key, sr, settings.DJANGO_CACHE_TIMEOUT)  # seconds

--- a/calisphere/cache_retry.py
+++ b/calisphere/cache_retry.py
@@ -70,9 +70,9 @@ def SOLR(**params):
         query.update({key: value})
     res = requests.post(solr_url, headers=solr_auth, data=query, verify=False)
     res.raise_for_status()
-    results = json.loads(res.content)
+    results = json.loads(res.content.decode('utf-8'))
     facet_counts = results.get('facet_counts', {})
-    for key, value in list(facet_counts.get('facet_fields', {}).items()):
+    for key, value in facet_counts.get('facet_fields', {}).items():
         # Make facet fields match edsu with grouper recipe
         facet_counts['facet_fields'][key] = dict(
             itertools.zip_longest(*[iter(value)] * 2, fillvalue=""))
@@ -99,7 +99,7 @@ def json_loads_url(url_or_req):
     data = cache.get(key)
     if not data:
         try:
-            data = json.loads(urllib.request.urlopen(url_or_req).read())
+            data = json.loads(urllib.request.urlopen(url_or_req).read().decode('utf-8'))
         except urllib.error.HTTPError:
             data = {}
     return data

--- a/calisphere/cache_retry.py
+++ b/calisphere/cache_retry.py
@@ -1,5 +1,6 @@
 """ logic for cache / retry for solr and JSON from registry
 """
+from __future__ import unicode_literals, print_function
 from django.core.cache import cache
 from django.conf import settings
 
@@ -57,7 +58,7 @@ SolrResults = namedtuple('SolrResults',
 
 def SOLR(**params):
     # replacement for edsu's solrpy based stuff
-    solr_url = u'{}/query/'.format(settings.SOLR_URL)
+    solr_url = '{}/query/'.format(settings.SOLR_URL)
     solr_auth = {'X-Authentication-Token': settings.SOLR_API_KEY}
     # Clean up optional parameters to match SOLR spec
     query = {}
@@ -134,7 +135,7 @@ def SOLR_raw(**kwargs):
     sr = cache.get(key)
     if not sr:
         # do the solr look up
-        solr_url = u'{}/query/'.format(settings.SOLR_URL)
+        solr_url = '{}/query/'.format(settings.SOLR_URL)
         solr_auth = {'X-Authentication-Token': settings.SOLR_API_KEY}
         # Clean up optional parameters to match SOLR spec
         query = {}

--- a/calisphere/collection_data.py
+++ b/calisphere/collection_data.py
@@ -6,7 +6,6 @@ standard_library.install_aliases()
 from builtins import chr
 from builtins import object
 import urllib.request, urllib.error, urllib.parse
-import json
 from collections import namedtuple
 import string
 import random

--- a/calisphere/collection_data.py
+++ b/calisphere/collection_data.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python
 
-import urllib2
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import chr
+from builtins import object
+import urllib.request, urllib.error, urllib.parse
 import json
 from collections import namedtuple
 import string
 import random
-from cache_retry import json_loads_url
+from .cache_retry import json_loads_url
 from django.core.cache import cache
 from django.conf import settings
 import time
@@ -33,7 +38,7 @@ class CollectionManager(object):
             url = (
                 '{0}/query?facet.field=collection_data&facet=on&rows=0&facet.limit=-1&facet.mincount=1'
                 .format(solr_url))
-            req = urllib2.Request(url, None,
+            req = urllib.request.Request(url, None,
                                   {'X-Authentication-Token': solr_key})
             save = {}
             save['data'] = self.data = json_loads_url(req)['facet_counts'][

--- a/calisphere/collection_data.py
+++ b/calisphere/collection_data.py
@@ -12,9 +12,9 @@ import time
 
 CollectionLink = namedtuple('CollectionLink', 'url, label')
 
+
 class CollectionManager(object):
     """ manage collection information that is parsed from solr facets """
-
 
     def __init__(self, solr_url, solr_key):
         cache_key = 'collection-manager'  # won't vary except on djano restart
@@ -25,36 +25,35 @@ class CollectionManager(object):
             self.parsed = saved['parsed']  # parsed into `CollectionLink`
             self.names = saved['names']  # dict of URL-> collection label
             self.split = saved['split']  # set up for a-z
-            self.no_collections = saved['no_collections']  # number of collections per letter for a-z
+            self.no_collections = saved[
+                'no_collections']  # number of collections per letter for a-z
             self.shuffled = saved['shuffled']  # For the collections explore
         else:
             # look it up from solr
             url = (
                 '{0}/query?facet.field=collection_data&facet=on&rows=0&facet.limit=-1&facet.mincount=1'
-                .format(
-                    solr_url
-                )
-            )
-            req = urllib2.Request(url, None, { 'X-Authentication-Token': solr_key  })
+                .format(solr_url))
+            req = urllib2.Request(url, None,
+                                  {'X-Authentication-Token': solr_key})
             save = {}
-            save['data'] = self.data = json_loads_url(req)['facet_counts']['facet_fields']['collection_data'][::2]
+            save['data'] = self.data = json_loads_url(req)['facet_counts'][
+                'facet_fields']['collection_data'][::2]
             self.parse()
             save['parsed'] = self.parsed
             save['names'] = self.names
             save['split'] = self.split
             save['no_collections'] = self.no_collections
             save['shuffled'] = self.shuffled
-            cache.set(cache_key, save, settings.DJANGO_CACHE_TIMEOUT )
-
+            cache.set(cache_key, save, settings.DJANGO_CACHE_TIMEOUT)
 
     def parse(self):
         def sort_key(collection_link):
-            return collection_link.label.translate({ord(c): None for c in string.punctuation}).upper()
+            return collection_link.label.translate(
+                {ord(c): None
+                 for c in string.punctuation}).upper()
 
         self.parsed = sorted(
-            [CollectionLink(*x.rsplit('::')) for x in self.data],
-            key=sort_key
-        )
+            [CollectionLink(*x.rsplit('::')) for x in self.data], key=sort_key)
 
         split_collections = {'num': [], 'a': []}
         names = {}
@@ -80,7 +79,7 @@ class CollectionManager(object):
         self.no_collections = []
         for c in list(string.ascii_lowercase):
             if len(self.split[c]) == 0:
-                self.no_collections.append(c);
+                self.no_collections.append(c)
 
         random.seed(time.strftime("%d/%m/%Y"))
 

--- a/calisphere/constants.py
+++ b/calisphere/constants.py
@@ -13,95 +13,167 @@
 #     ('collection_data', 'Collection'),
 # ]
 
-FACET_FILTER_TYPES = [
-    {'facet': 'type_ss', 'display_name': 'Type of Item', 'filter': 'type_ss'},
-    {'facet': 'facet_decade', 'display_name': 'Decade', 'filter': 'facet_decade'},
-    {'facet': 'repository_data', 'display_name': 'Contributing Institution', 'filter': 'repository_url'},
-    {'facet': 'collection_data', 'display_name': 'Collection', 'filter': 'collection_url'}
-]
+FACET_FILTER_TYPES = [{
+    'facet': 'type_ss',
+    'display_name': 'Type of Item',
+    'filter': 'type_ss'
+}, {
+    'facet': 'facet_decade',
+    'display_name': 'Decade',
+    'filter': 'facet_decade'
+}, {
+    'facet': 'repository_data',
+    'display_name': 'Contributing Institution',
+    'filter': 'repository_url'
+}, {
+    'facet': 'collection_data',
+    'display_name': 'Collection',
+    'filter': 'collection_url'
+}]
 
 # Make a copy of FACET_FILTER_TYPES to reset to original.
 DEFAULT_FACET_FILTER_TYPES = FACET_FILTER_TYPES[:]
 
-CAMPUS_LIST = [
- {'featuredImage': {'src': '/thumb-uc_berkeley.jpg',
-                    'url': '/item/ark:/13030/ft400005ht/'},
-  'id': '1',
-  'name': 'UC Berkeley',
-  'slug': 'UCB'},
- {'featuredImage': {'src': '/thumb-uc_davis.jpg',
-                    'url': '/item/ark:/13030/kt6779r95t/'},
-  'id': '2',
-  'name': 'UC Davis',
-  'slug': 'UCD'},
- {'featuredImage': {'src': '/thumb-uc_irvine.jpg',
-                    'url': '/item/ark:/13030/hb6s2007ns/'},
-  'id': '3',
-  'name': 'UC Irvine',
-  'slug': 'UCI'},
- {'featuredImage': {'src': '/thumb-uc_la.jpg',
-                    'url': '/item/ark:/21198/zz002bzhj9/'},
-  'id': '10',
-  'name': 'UCLA',
-  'slug': 'UCLA'},
- {'featuredImage': {'src': '/thumb-uc_merced.jpg',
-                    'url': '/item/630a2224-a666-47ab-bd51-cda382108b6a/'},
-  'id': '4',
-  'name': 'UC Merced',
-  'slug': 'UCM'},
- {'featuredImage': {'src': '/thumb-uc_riverside.jpg',
-                    'url': '/item/3669304d-960c-4c1d-b870-32c9dc3b288b/'},
-  'id': '5',
-  'name': 'UC Riverside',
-  'slug': 'UCR'},
- {'featuredImage': {'src': '/thumb-uc_sandiego.jpg',
-                    'url': '/item/ark:/20775/bb34824128/'},
-  'id': '6',
-  'name': 'UC San Diego',
-  'slug': 'UCSD'},
- {'featuredImage': {'src': '/thumb-uc_sf-v2.jpg',
-                    'url': '/item/3fe65b42-122e-48de-8e4b-bc8dcf531216/'},
-  'id': '7',
-  'name': 'UC San Francisco',
-  'slug': 'UCSF'},
- {'featuredImage': {'src': '/thumb-uc_santabarbara.jpg',
-                    'url': '/item/ark:/13030/kt00003279/'},
-  'id': '8',
-  'name': 'UC Santa Barbara',
-  'slug': 'UCSB'},
- {'featuredImage': {'src': '/thumb-uc_santacruz.jpg',
-                    'url': '/item/ark:/13030/hb4b69n74p/'},
-  'id': '9',
-  'name': 'UC Santa Cruz',
-  'slug': 'UCSC'}]
+CAMPUS_LIST = [{
+    'featuredImage': {
+        'src': '/thumb-uc_berkeley.jpg',
+        'url': '/item/ark:/13030/ft400005ht/'
+    },
+    'id': '1',
+    'name': 'UC Berkeley',
+    'slug': 'UCB'
+}, {
+    'featuredImage': {
+        'src': '/thumb-uc_davis.jpg',
+        'url': '/item/ark:/13030/kt6779r95t/'
+    },
+    'id': '2',
+    'name': 'UC Davis',
+    'slug': 'UCD'
+}, {
+    'featuredImage': {
+        'src': '/thumb-uc_irvine.jpg',
+        'url': '/item/ark:/13030/hb6s2007ns/'
+    },
+    'id': '3',
+    'name': 'UC Irvine',
+    'slug': 'UCI'
+}, {
+    'featuredImage': {
+        'src': '/thumb-uc_la.jpg',
+        'url': '/item/ark:/21198/zz002bzhj9/'
+    },
+    'id': '10',
+    'name': 'UCLA',
+    'slug': 'UCLA'
+}, {
+    'featuredImage': {
+        'src': '/thumb-uc_merced.jpg',
+        'url': '/item/630a2224-a666-47ab-bd51-cda382108b6a/'
+    },
+    'id': '4',
+    'name': 'UC Merced',
+    'slug': 'UCM'
+}, {
+    'featuredImage': {
+        'src': '/thumb-uc_riverside.jpg',
+        'url': '/item/3669304d-960c-4c1d-b870-32c9dc3b288b/'
+    },
+    'id': '5',
+    'name': 'UC Riverside',
+    'slug': 'UCR'
+}, {
+    'featuredImage': {
+        'src': '/thumb-uc_sandiego.jpg',
+        'url': '/item/ark:/20775/bb34824128/'
+    },
+    'id': '6',
+    'name': 'UC San Diego',
+    'slug': 'UCSD'
+}, {
+    'featuredImage': {
+        'src': '/thumb-uc_sf-v2.jpg',
+        'url': '/item/3fe65b42-122e-48de-8e4b-bc8dcf531216/'
+    },
+    'id': '7',
+    'name': 'UC San Francisco',
+    'slug': 'UCSF'
+}, {
+    'featuredImage': {
+        'src': '/thumb-uc_santabarbara.jpg',
+        'url': '/item/ark:/13030/kt00003279/'
+    },
+    'id': '8',
+    'name': 'UC Santa Barbara',
+    'slug': 'UCSB'
+}, {
+    'featuredImage': {
+        'src': '/thumb-uc_santacruz.jpg',
+        'url': '/item/ark:/13030/hb4b69n74p/'
+    },
+    'id': '9',
+    'name': 'UC Santa Cruz',
+    'slug': 'UCSC'
+}]
 
-FEATURED_UNITS = [{'featuredImage': {'src': '/thumb-inst_marin.jpg',
-                    'url': '/item/ark:/13030/kt609nf54t/'},
-  'id': '87'},
- {'featuredImage': {'src': '/thumb-inst_la-public-library.jpg',
-                    'url': '/item/26094--LAPL00027224/'},
-  'id': '143'},
- {'featuredImage': {'src': '/thumb-inst_sf-public-library.jpg',
-                    'url': '/item/26095--AAE-0653/'},
-  'id': '144'},
- {'featuredImage': {'src': '/thumb-inst_humboldt-state-university.jpg',
-                    'url': '/item/ark:/13030/ft096n9702/'},
-  'id': '77'},
- {'featuredImage': {'src': '/thumb-inst_museum.jpg',
-                    'url': '/item/ark:/13030/kt5v19q1h9/'},
-  'id': '93'},
- {'featuredImage': {'src': '/thumb-inst_japanese.jpg',
-                    'url': '/item/ark:/13030/tf3489n611/'},
-  'id': '80'},
- {'featuredImage': {'src': '/thumb-inst_riverside.jpg',
-                    'url': '/item/ark:/13030/kt7z09r48v/'},
-  'id': '108'},
- {'featuredImage': {'src': '/thumb-inst_huntington.jpg',
-                    'url': '/item/ark:/13030/kt5t1nd9ph/'},
-  'id': '146'},
- {'featuredImage': {'src': '/thumb-inst_lgbt.jpg',
-                    'url': '/item/ark:/13030/kt7d5nf4s3/'},
-  'id': '72'},
- {'featuredImage': {'src': '/thumb-inst_tulare-county.jpg',
-                    'url': '/item/ark:/13030/c800007n/'},
-  'id': '149'}]
+FEATURED_UNITS = [{
+    'featuredImage': {
+        'src': '/thumb-inst_marin.jpg',
+        'url': '/item/ark:/13030/kt609nf54t/'
+    },
+    'id': '87'
+}, {
+    'featuredImage': {
+        'src': '/thumb-inst_la-public-library.jpg',
+        'url': '/item/26094--LAPL00027224/'
+    },
+    'id': '143'
+}, {
+    'featuredImage': {
+        'src': '/thumb-inst_sf-public-library.jpg',
+        'url': '/item/26095--AAE-0653/'
+    },
+    'id': '144'
+}, {
+    'featuredImage': {
+        'src': '/thumb-inst_humboldt-state-university.jpg',
+        'url': '/item/ark:/13030/ft096n9702/'
+    },
+    'id': '77'
+}, {
+    'featuredImage': {
+        'src': '/thumb-inst_museum.jpg',
+        'url': '/item/ark:/13030/kt5v19q1h9/'
+    },
+    'id': '93'
+}, {
+    'featuredImage': {
+        'src': '/thumb-inst_japanese.jpg',
+        'url': '/item/ark:/13030/tf3489n611/'
+    },
+    'id': '80'
+}, {
+    'featuredImage': {
+        'src': '/thumb-inst_riverside.jpg',
+        'url': '/item/ark:/13030/kt7z09r48v/'
+    },
+    'id': '108'
+}, {
+    'featuredImage': {
+        'src': '/thumb-inst_huntington.jpg',
+        'url': '/item/ark:/13030/kt5t1nd9ph/'
+    },
+    'id': '146'
+}, {
+    'featuredImage': {
+        'src': '/thumb-inst_lgbt.jpg',
+        'url': '/item/ark:/13030/kt7d5nf4s3/'
+    },
+    'id': '72'
+}, {
+    'featuredImage': {
+        'src': '/thumb-inst_tulare-county.jpg',
+        'url': '/item/ark:/13030/c800007n/'
+    },
+    'id': '149'
+}]

--- a/calisphere/contact_form_view.py
+++ b/calisphere/contact_form_view.py
@@ -1,11 +1,13 @@
 from __future__ import unicode_literals, print_function
+from future import standard_library
+standard_library.install_aliases()
 from collections import OrderedDict
 from django import forms
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from contact_form.views import ContactFormView
 from contact_form.forms import ContactForm
-import urlparse
+import urllib.parse
 
 
 class CalisphereContactForm(ContactForm):
@@ -39,7 +41,7 @@ class CalisphereContactForm(ContactForm):
             'body',
             'referer',
         ]
-        if (self.fields.has_key('keyOrder')):
+        if ('keyOrder' in self.fields):
             self.fields.keyOrder = fields_keyOrder
         else:
             self.fields = OrderedDict((k, self.fields[k])
@@ -54,5 +56,5 @@ class CalisphereContactFormView(ContactFormView):
     def get_success_url(self):
         # fix the host name to stay on the proxy http://stackoverflow.com/a/5686726/1763984
         # pass the referer on to the "sent" email confirmation page
-        return urlparse.urljoin(settings.UCLDC_FRONT, '{0}?referer={1}'.format(
+        return urllib.parse.urljoin(settings.UCLDC_FRONT, '{0}?referer={1}'.format(
             reverse('contact_form_sent'), self.request.POST.get('referer')))

--- a/calisphere/contact_form_view.py
+++ b/calisphere/contact_form_view.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals, print_function
 from collections import OrderedDict
 from django import forms
 from django.conf import settings
@@ -10,22 +11,22 @@ import urlparse
 class CalisphereContactForm(ContactForm):
     name = forms.CharField(
         max_length=100,
-        label=u'Name:',
+        label='Name:',
         widget=forms.TextInput(attrs={'placeholder': 'Your full name'}),
     )
     email = forms.EmailField(
         max_length=200,
-        label=u'Email:',
+        label='Email:',
         widget=forms.TextInput(attrs={'placeholder': 'Your email'}),
     )
     email2 = forms.EmailField(
         max_length=200,
-        label=u'Verify Email:',
+        label='Verify Email:',
         widget=forms.TextInput(attrs={'placeholder': 'Verify your email'}),
     )
     body = forms.CharField(
         widget=forms.Textarea,
-        label=u'Message',
+        label='Message',
     )
     referer = forms.CharField(widget=forms.HiddenInput())
 
@@ -61,7 +62,7 @@ class CalisphereContactFormView(ContactFormView):
         # pass the referer on to the "sent" email confirmation page
         return urlparse.urljoin(
             settings.UCLDC_FRONT ,
-            u'{0}?referer={1}'.format(
+            '{0}?referer={1}'.format(
                 reverse('contact_form_sent'),
                 self.request.POST.get('referer')
             )

--- a/calisphere/contact_form_view.py
+++ b/calisphere/contact_form_view.py
@@ -12,32 +12,26 @@ class CalisphereContactForm(ContactForm):
     name = forms.CharField(
         max_length=100,
         label='Name:',
-        widget=forms.TextInput(attrs={'placeholder': 'Your full name'}),
-    )
+        widget=forms.TextInput(attrs={'placeholder': 'Your full name'}), )
     email = forms.EmailField(
         max_length=200,
         label='Email:',
-        widget=forms.TextInput(attrs={'placeholder': 'Your email'}),
-    )
+        widget=forms.TextInput(attrs={'placeholder': 'Your email'}), )
     email2 = forms.EmailField(
         max_length=200,
         label='Verify Email:',
-        widget=forms.TextInput(attrs={'placeholder': 'Verify your email'}),
-    )
+        widget=forms.TextInput(attrs={'placeholder': 'Verify your email'}), )
     body = forms.CharField(
         widget=forms.Textarea,
-        label='Message',
-    )
+        label='Message', )
     referer = forms.CharField(widget=forms.HiddenInput())
 
     template_name = 'contact_form/contact_form.txt'
     subject_template_name = "contact_form/contact_form_subject.txt"
 
     def __init__(self, request, *args, **kwargs):
-        super(
-            CalisphereContactForm,
-            self
-        ).__init__(request=request, *args, **kwargs)
+        super(CalisphereContactForm, self).__init__(
+            request=request, *args, **kwargs)
         fields_keyOrder = [
             'name',
             'email',
@@ -48,22 +42,17 @@ class CalisphereContactForm(ContactForm):
         if (self.fields.has_key('keyOrder')):
             self.fields.keyOrder = fields_keyOrder
         else:
-            self.fields = OrderedDict(
-                (k, self.fields[k]) for k in fields_keyOrder
-            )
+            self.fields = OrderedDict((k, self.fields[k])
+                                      for k in fields_keyOrder)
 
 
 class CalisphereContactFormView(ContactFormView):
     '''view for main email contact form'''
     # use our custom form
     form_class = CalisphereContactForm
+
     def get_success_url(self):
         # fix the host name to stay on the proxy http://stackoverflow.com/a/5686726/1763984
         # pass the referer on to the "sent" email confirmation page
-        return urlparse.urljoin(
-            settings.UCLDC_FRONT ,
-            '{0}?referer={1}'.format(
-                reverse('contact_form_sent'),
-                self.request.POST.get('referer')
-            )
-        )
+        return urlparse.urljoin(settings.UCLDC_FRONT, '{0}?referer={1}'.format(
+            reverse('contact_form_sent'), self.request.POST.get('referer')))

--- a/calisphere/home.py
+++ b/calisphere/home.py
@@ -20,7 +20,6 @@ class HomeView(TemplateView):
         this_data = os.path.join(this_dir, 'home-data.json')
         self.home_data = json.loads(open(this_data).read())
 
-
     @method_decorator(gzip_page)
     def get(self, request):
         """ view for home page """
@@ -30,7 +29,10 @@ class HomeView(TemplateView):
 
         # return one lock_up; and arrays for the featured stuff
         return render(request, self.template_name, {
-            'lock_up': self.home_data['home'][0],
-            'uc_partners': self.home_data['uc_partners'],
-            'statewide_partners': self.home_data['statewide_partners'],
+            'lock_up':
+            self.home_data['home'][0],
+            'uc_partners':
+            self.home_data['uc_partners'],
+            'statewide_partners':
+            self.home_data['statewide_partners'],
         })

--- a/calisphere/management/commands/calisphere_refresh_sitemaps.py
+++ b/calisphere/management/commands/calisphere_refresh_sitemaps.py
@@ -1,10 +1,12 @@
-from django.core.management.base import BaseCommand 
+from django.core.management.base import BaseCommand
 from calisphere.sitemap_generator import CalisphereSitemapGenerator
+
 
 class Command(BaseCommand):
     command = None
     help = 'generate sitemaps files for Calisphere'
 
     def handle(self, **options):
-        generator = CalisphereSitemapGenerator(int(options.get('verbosity', 0)))
+        generator = CalisphereSitemapGenerator(
+            int(options.get('verbosity', 0)))
         generator.write()

--- a/calisphere/registry_data.py
+++ b/calisphere/registry_data.py
@@ -5,8 +5,6 @@ import urlparse
 
 
 class RegistryManager(object):
-
-
     def init_registry_data(self, path):
         base = settings.UCLDC_REGISTRY_URL
         page_one = json_loads_url(urlparse.urljoin(base, path))
@@ -19,13 +17,11 @@ class RegistryManager(object):
 
         return out
 
-
     def __init__(self):
         repository_path = '/api/v1/repository/?format=json'
         # collection_path = '/api/v1/collection/?format=json'
         self.repository_data = self.init_registry_data(repository_path)
         # self.collection_data = self.init_registry_data(collection_path)
-
 
 
 """

--- a/calisphere/registry_data.py
+++ b/calisphere/registry_data.py
@@ -1,13 +1,7 @@
+from __future__ import unicode_literals, print_function
 from django.conf import settings
-import urllib2
-import json
-from collections import namedtuple
-import string
-import random
-from cache_retry import json_loads_url
-import time
+from .cache_retry import json_loads_url
 import urlparse
-from pprint import pprint as pp
 
 
 class RegistryManager(object):

--- a/calisphere/registry_data.py
+++ b/calisphere/registry_data.py
@@ -1,17 +1,20 @@
 from __future__ import unicode_literals, print_function
+from future import standard_library
+standard_library.install_aliases()
+from builtins import object
 from django.conf import settings
 from .cache_retry import json_loads_url
-import urlparse
+import urllib.parse
 
 
 class RegistryManager(object):
     def init_registry_data(self, path):
         base = settings.UCLDC_REGISTRY_URL
-        page_one = json_loads_url(urlparse.urljoin(base, path))
+        page_one = json_loads_url(urllib.parse.urljoin(base, path))
         out = dict((x['id'], x) for x in page_one['objects'])
         next_path = page_one['meta']['next']
         while next_path:
-            next_page = json_loads_url(urlparse.urljoin(base, next_path))
+            next_page = json_loads_url(urllib.parse.urljoin(base, next_path))
             out.update(dict((x['id'], x) for x in next_page['objects']))
             next_path = next_page['meta']['next']
 

--- a/calisphere/sitemap_generator.py
+++ b/calisphere/sitemap_generator.py
@@ -10,6 +10,7 @@ from static_sitemaps.generator import SitemapGenerator
 
 class CalisphereSitemapGenerator(SitemapGenerator):
     ''' subclass django-static-sitemaps '''
+
     def __init__(self, verbosity):
         SitemapGenerator.__init__(self, verbosity)
         self.baseurl = self.normalize_url(conf.get_url())
@@ -27,9 +28,9 @@ class CalisphereSitemapGenerator(SitemapGenerator):
         path = os.path.join(conf.ROOT_DIR, 'sitemap.xml')
         self.out('Writing index file.', 2)
 
-        output = loader.render_to_string(conf.INDEX_TEMPLATE, {'sitemaps': parts})
+        output = loader.render_to_string(conf.INDEX_TEMPLATE,
+                                         {'sitemaps': parts})
         self._write(path, output)
-
 
     def write_data_regular(self, section, site):
         ''' process regular Django sitemap, which assumes list data '''
@@ -40,8 +41,10 @@ class CalisphereSitemapGenerator(SitemapGenerator):
 
         parts = []
         for page in range(1, pages + 1):
-            filename = conf.FILENAME_TEMPLATE % {'section': section,
-                                                 'page': page}
+            filename = conf.FILENAME_TEMPLATE % {
+                'section': section,
+                'page': page
+            }
             lastmod = self.write_page(site, page, filename)
 
             if conf.USE_GZIP:
@@ -57,21 +60,29 @@ class CalisphereSitemapGenerator(SitemapGenerator):
     def write_data_fast(self, section, site):
         ''' process data using generator and streaming xml '''
         # FIXME need to generalize this code if we ever want to use it for anything other than Calisphere items
-        items = site().items() # generator yielding all items
+        items = site().items()  # generator yielding all items
 
         parts = []
 
         for page in xrange(site().num_pages):
-            filename = conf.FILENAME_TEMPLATE % {'section': section, 'page': page + 1}
+            filename = conf.FILENAME_TEMPLATE % {
+                'section': section,
+                'page': page + 1
+            }
             self.out('Writing sitemap %s' % filename, 2)
             path = os.path.join(conf.ROOT_DIR, filename)
             with open(path, 'w+') as f:
                 f.write('<?xml version="1.0" encoding="UTF-8"?>')
-                f.write('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">')
+                f.write(
+                    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">'
+                )
                 for n in xrange(site().limit):
                     item = next(items)
                     f.write('<url>')
-                    f.write('<loc>https://calisphere.org/item/{0}/</loc>'.format(item['id'])) # FIXME hardcoded to only work for Calisphere items
+                    f.write(
+                        '<loc>https://calisphere.org/item/{0}/</loc>'.format(
+                            item['id']
+                        ))  # FIXME hardcoded to only work for Calisphere items
                     # <lastmod>
                     f.write('<lastmod>{0}</lastmod>'.format(item['timestamp']))
                     # <changefreq>
@@ -79,7 +90,9 @@ class CalisphereSitemapGenerator(SitemapGenerator):
                     # <lastmod>
                     # FIXME hardcoded to only work for Calisphere items
                     if item['reference_image_md5']:
-                        f.write('<image:image><image:loc>https://calisphere.org/crop/999x999/{0}</image:loc></image:image>'.format(item['reference_image_md5']))
+                        f.write(
+                            '<image:image><image:loc>https://calisphere.org/crop/999x999/{0}</image:loc></image:image>'.
+                            format(item['reference_image_md5']))
                     f.write('</url>')
                 f.write('</urlset>')
 
@@ -87,11 +100,15 @@ class CalisphereSitemapGenerator(SitemapGenerator):
                 self.compress(path)
                 filename += '.gz'
             # implement lastmod?
-            parts.append({'lastmod': None, 'location': '{}{}'.format(self.baseurl, filename)})
+            parts.append({
+                'lastmod': None,
+                'location': '{}{}'.format(self.baseurl, filename)
+            })
 
         return parts
 
     def compress(self, path):
         self.out('Compressing...')
-        with open(path, 'rb') as f_in, gzip.open('{}.gz'.format(path), 'wb') as f_out:
+        with open(path, 'rb') as f_in, gzip.open('{}.gz'.format(path),
+                                                 'wb') as f_out:
             shutil.copyfileobj(f_in, f_out)

--- a/calisphere/sitemap_generator.py
+++ b/calisphere/sitemap_generator.py
@@ -1,4 +1,6 @@
 from __future__ import unicode_literals, print_function
+from builtins import next
+from builtins import range
 import os
 import gzip
 import shutil
@@ -19,7 +21,7 @@ class CalisphereSitemapGenerator(SitemapGenerator):
         ''' write sitemap.xml index file and the sitemap files it references '''
         parts = []
 
-        for section, site in self.sitemaps.items():
+        for section, site in list(self.sitemaps.items()):
             if issubclass(site, RegularDjangoSitemap):
                 parts.extend(self.write_data_regular(section, site))
             else:
@@ -60,11 +62,11 @@ class CalisphereSitemapGenerator(SitemapGenerator):
     def write_data_fast(self, section, site):
         ''' process data using generator and streaming xml '''
         # FIXME need to generalize this code if we ever want to use it for anything other than Calisphere items
-        items = site().items()  # generator yielding all items
+        items = list(site().items())  # generator yielding all items
 
         parts = []
 
-        for page in xrange(site().num_pages):
+        for page in range(site().num_pages):
             filename = conf.FILENAME_TEMPLATE % {
                 'section': section,
                 'page': page + 1
@@ -76,7 +78,7 @@ class CalisphereSitemapGenerator(SitemapGenerator):
                 f.write(
                     '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">'
                 )
-                for n in xrange(site().limit):
+                for n in range(site().limit):
                     item = next(items)
                     f.write('<url>')
                     f.write(

--- a/calisphere/sitemap_generator.py
+++ b/calisphere/sitemap_generator.py
@@ -3,9 +3,9 @@ import os
 import gzip
 import shutil
 from django.template import loader
-from django.conf import settings
 from django.contrib.sitemaps import Sitemap as RegularDjangoSitemap
 from static_sitemaps.generator import SitemapGenerator
+from static_sitemaps import conf
 
 
 class CalisphereSitemapGenerator(SitemapGenerator):

--- a/calisphere/sitemap_generator.py
+++ b/calisphere/sitemap_generator.py
@@ -62,7 +62,7 @@ class CalisphereSitemapGenerator(SitemapGenerator):
     def write_data_fast(self, section, site):
         ''' process data using generator and streaming xml '''
         # FIXME need to generalize this code if we ever want to use it for anything other than Calisphere items
-        items = list(site().items())  # generator yielding all items
+        items = site().items()  # generator yielding all items
 
         parts = []
 

--- a/calisphere/sitemap_generator.py
+++ b/calisphere/sitemap_generator.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals, print_function
 import os
 import gzip
 import shutil
@@ -5,8 +6,7 @@ from django.template import loader
 from django.conf import settings
 from django.contrib.sitemaps import Sitemap as RegularDjangoSitemap
 from static_sitemaps.generator import SitemapGenerator
-from static_sitemaps import conf
-from six import BytesIO
+
 
 class CalisphereSitemapGenerator(SitemapGenerator):
     ''' subclass django-static-sitemaps '''
@@ -15,11 +15,11 @@ class CalisphereSitemapGenerator(SitemapGenerator):
         self.baseurl = self.normalize_url(conf.get_url())
 
     def write_index(self):
-        ''' write sitemap.xml index file and the sitemap files it references ''' 
+        ''' write sitemap.xml index file and the sitemap files it references '''
         parts = []
 
         for section, site in self.sitemaps.items():
-            if issubclass(site, RegularDjangoSitemap): 
+            if issubclass(site, RegularDjangoSitemap):
                 parts.extend(self.write_data_regular(section, site))
             else:
                 parts.extend(self.write_data_fast(section, site))
@@ -55,7 +55,7 @@ class CalisphereSitemapGenerator(SitemapGenerator):
         return parts
 
     def write_data_fast(self, section, site):
-        ''' process data using generator and streaming xml ''' 
+        ''' process data using generator and streaming xml '''
         # FIXME need to generalize this code if we ever want to use it for anything other than Calisphere items
         items = site().items() # generator yielding all items
 
@@ -71,9 +71,9 @@ class CalisphereSitemapGenerator(SitemapGenerator):
                 for n in xrange(site().limit):
                     item = next(items)
                     f.write('<url>')
-                    f.write(u'<loc>https://calisphere.org/item/{0}/</loc>'.format(item['id'])) # FIXME hardcoded to only work for Calisphere items
+                    f.write('<loc>https://calisphere.org/item/{0}/</loc>'.format(item['id'])) # FIXME hardcoded to only work for Calisphere items
                     # <lastmod>
-                    f.write(u'<lastmod>{0}</lastmod>'.format(item['timestamp']))
+                    f.write('<lastmod>{0}</lastmod>'.format(item['timestamp']))
                     # <changefreq>
                     # <priority>
                     # <lastmod>
@@ -82,7 +82,7 @@ class CalisphereSitemapGenerator(SitemapGenerator):
                         f.write('<image:image><image:loc>https://calisphere.org/crop/999x999/{0}</image:loc></image:image>'.format(item['reference_image_md5']))
                     f.write('</url>')
                 f.write('</urlset>')
- 
+
             if conf.USE_GZIP:
                 self.compress(path)
                 filename += '.gz'

--- a/calisphere/sitemaps.py
+++ b/calisphere/sitemaps.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import object
+from past.utils import old_div
 import re
 import time
 
@@ -35,7 +38,7 @@ class StaticSitemap(HttpsSitemap):
 
 class InstitutionSitemap(HttpsSitemap):
     def items(self):
-        return app.registry.repository_data.keys()
+        return list(app.registry.repository_data.keys())
 
     def location(self, item):
         return reverse(
@@ -73,7 +76,7 @@ class ItemSitemap(object):
 
         self.limit = 15000  # 50,000 is google limit on urls per sitemap file
         self.solr_total = SOLR_select_nocache(q='').numFound
-        self.num_pages = self.solr_total / self.limit
+        self.num_pages = old_div(self.solr_total, self.limit)
 
     def items(self):
         ''' returns a generator containing data for all items in solr '''

--- a/calisphere/sitemaps.py
+++ b/calisphere/sitemaps.py
@@ -18,54 +18,47 @@ class HttpsSitemap(Sitemap):
 
 
 class StaticSitemap(HttpsSitemap):
-
-
     def items(self):
         return [
-          'calisphere:collectionsDirectory',
-          'calisphere:about',
-          'calisphere:help',
-          'calisphere:termsOfUse',
-          'calisphere:privacyStatement',
-          'calisphere:outreach',
-          'calisphere:contribute',
+            'calisphere:collectionsDirectory',
+            'calisphere:about',
+            'calisphere:help',
+            'calisphere:termsOfUse',
+            'calisphere:privacyStatement',
+            'calisphere:outreach',
+            'calisphere:contribute',
         ]
-
 
     def location(self, item):
         return reverse(item)
 
 
 class InstitutionSitemap(HttpsSitemap):
-
     def items(self):
         return app.registry.repository_data.keys()
 
     def location(self, item):
         return reverse(
             'calisphere:repositoryView',
-            kwargs={'repository_id': item, 'subnav': 'items'}
-        )
+            kwargs={'repository_id': item,
+                    'subnav': 'items'})
 
 
 class CollectionSitemap(HttpsSitemap):
-
-
     def items(self):
-        return CollectionManager(settings.SOLR_URL, settings.SOLR_API_KEY).parsed
-
+        return CollectionManager(settings.SOLR_URL,
+                                 settings.SOLR_API_KEY).parsed
 
     def location(self, item):
-        col_id = re.match(r'^https://registry.cdlib.org/api/v1/collection/(?P<collection_id>\d+)/$',
-                          item.url)
+        col_id = re.match(
+            r'^https://registry.cdlib.org/api/v1/collection/(?P<collection_id>\d+)/$',
+            item.url)
         return reverse(
             'calisphere:collectionView',
-            kwargs={'collection_id': col_id.group('collection_id')}
-        )
+            kwargs={'collection_id': col_id.group('collection_id')})
 
 
 class ItemSitemap(object):
-
     '''
         class for generating Calisphere item sitemaps in conjunction with
         calisphere.sitemap_generator, which is a subclass of django-static-sitemaps
@@ -75,11 +68,12 @@ class ItemSitemap(object):
 
         Use a generator of solr results rather than a list, which is too memory intensive.
     '''
+
     def __init__(self):
 
         self.limit = 15000  # 50,000 is google limit on urls per sitemap file
         self.solr_total = SOLR_select_nocache(q='').numFound
-        self.num_pages = self.solr_total/self.limit
+        self.num_pages = self.solr_total / self.limit
 
     def items(self):
         ''' returns a generator containing data for all items in solr '''
@@ -91,18 +85,12 @@ class ItemSitemap(object):
             'sort': 'score desc,id desc',
         }
 
-
         data_iter = self.get_iter(base_query)
 
         return data_iter
 
-
     def location(self, item):
-        return reverse(
-            'calisphere:itemView',
-            kwargs={'item_id': item}
-        )
-
+        return reverse('calisphere:itemView', kwargs={'item_id': item})
 
     def get_iter(self, params):
         nextCursorMark = '*'
@@ -112,7 +100,11 @@ class ItemSitemap(object):
             if len(solr_page.results) == 0:
                 break
             for item in solr_page.results:
-                yield {'id': item.get('id'), 'reference_image_md5': item.get('reference_image_md5'), 'timestamp': item.get('timestamp')}
+                yield {
+                    'id': item.get('id'),
+                    'reference_image_md5': item.get('reference_image_md5'),
+                    'timestamp': item.get('timestamp')
+                }
 
             nextCursorMark = solr_page.nextCursorMark
 

--- a/calisphere/sitemaps.py
+++ b/calisphere/sitemaps.py
@@ -8,7 +8,7 @@ from django.conf import settings
 
 from calisphere.collection_data import CollectionManager
 
-from cache_retry import SOLR_select_nocache
+from .cache_retry import SOLR_select_nocache
 
 app = apps.get_app_config('calisphere')
 

--- a/calisphere/templatetags/calisphere-extras.py
+++ b/calisphere/templatetags/calisphere-extras.py
@@ -3,9 +3,10 @@ import ast
 
 register = Library()
 
+
 @register.filter
-def get_range( value ):
-  """
+def get_range(value):
+    """
     Filter - returns a list containing range made from given value
     Usage (in template):
 
@@ -24,11 +25,13 @@ def get_range( value ):
 
     https://djangosnippets.org/snippets/1357/
   """
-  return range( value )
+    return range(value)
+
 
 @register.filter
-def string_lookup( s, key ):
+def string_lookup(s, key):
     return ast.literal_eval(s)[key]
+
 
 @register.filter
 def dictionary_length(dictionary):
@@ -37,25 +40,31 @@ def dictionary_length(dictionary):
         length = length + len(dictionary[key])
     return length
 
+
 @register.filter
 def get_item(dictionary, key):
-  return dictionary.get(key, '')
+    return dictionary.get(key, '')
+
 
 @register.filter
-def multiply( a, b ):
+def multiply(a, b):
     return str(int(a) * int(b))
 
+
 @register.filter
-def subtract( a, b ):
+def subtract(a, b):
     return int(a) - int(b)
 
-@register.filter
-def divide( a, b ):
-    return int(int(a) / int(b))
 
 @register.filter
-def current_page( start, rows ):
+def divide(a, b):
+    return int(int(a) / int(b))
+
+
+@register.filter
+def current_page(start, rows):
     return int(int(start) / int(rows)) + 1
+
 
 @register.filter
 def is_string(val):

--- a/calisphere/templatetags/calisphere-extras.py
+++ b/calisphere/templatetags/calisphere-extras.py
@@ -1,5 +1,4 @@
 from django.template import Library
-import re
 import ast
 
 register = Library()

--- a/calisphere/templatetags/calisphere-extras.py
+++ b/calisphere/templatetags/calisphere-extras.py
@@ -1,3 +1,8 @@
+from __future__ import division
+from builtins import str
+from builtins import range
+from past.builtins import basestring
+from past.utils import old_div
 from django.template import Library
 import ast
 
@@ -25,7 +30,7 @@ def get_range(value):
 
     https://djangosnippets.org/snippets/1357/
   """
-    return range(value)
+    return list(range(value))
 
 
 @register.filter
@@ -58,12 +63,12 @@ def subtract(a, b):
 
 @register.filter
 def divide(a, b):
-    return int(int(a) / int(b))
+    return int(old_div(int(a), int(b)))
 
 
 @register.filter
 def current_page(start, rows):
-    return int(int(start) / int(rows)) + 1
+    return int(old_div(int(start), int(rows))) + 1
 
 
 @register.filter

--- a/calisphere/tests.py
+++ b/calisphere/tests.py
@@ -1,3 +1,8 @@
-from django.test import TestCase
+from django.test import Client
 
 # Create your tests here.
+
+c = Client()
+
+c.get('/')
+c.get('/exhibitions/')

--- a/calisphere/urls.py
+++ b/calisphere/urls.py
@@ -10,38 +10,94 @@ urlpatterns = [
     url(r'^$', HomeView.as_view(), name='home'),
     url(r'^search/$', views.search, name='search'),
     url(r'^item/(?P<item_id>.*)/$', views.itemView, name='itemView'),
-
-    url(r'^collections/$', views.collectionsDirectory, name='collectionsDirectory'),
-    url(r'^collections/(?P<collection_letter>[a-zA-Z]{1})/', views.collectionsAZ, name='collectionsAZ'),
-    url(r'^collections/(?P<collection_letter>num)/', views.collectionsAZ, name='collectionsAZ'),
-    url(r'^collections/(?P<collection_id>\d*)/', views.collectionView, name='collectionView'),
+    url(
+        r'^collections/$',
+        views.collectionsDirectory,
+        name='collectionsDirectory'),
+    url(
+        r'^collections/(?P<collection_letter>[a-zA-Z]{1})/',
+        views.collectionsAZ,
+        name='collectionsAZ'),
+    url(
+        r'^collections/(?P<collection_letter>num)/',
+        views.collectionsAZ,
+        name='collectionsAZ'),
+    url(
+        r'^collections/(?P<collection_id>\d*)/',
+        views.collectionView,
+        name='collectionView'),
 
     # Redirects to new 'exhibitions'
-    url(r'^collections/themed/$', RedirectView.as_view(url='/exhibitions/'), name='themedCollections'),
-    url(r'^collections/cal-cultures/$', RedirectView.as_view(url='/cal-cultures/'), name='calCultures'),
-    url(r'^collections/jarda/$', RedirectView.as_view(url='/exhibitions/t11/jarda/'), name='jarda'),
-
-    url(r'^collections/titleSearch/$', views.collectionsSearch, name='collectionsTitleSearch'),
-    url(r'^collections/titles.json$', views.collectionsTitles, name='collectionsTitleData'),
-
-    url(r'^institution/(?P<repository_id>\d*)(?:/(?P<subnav>items|collections))?/', views.repositoryView, name='repositoryView'),
-    url(r'^(?P<campus_slug>UC\w{1,2})(?:/(?P<subnav>items|collections|institutions))?/', views.campusView, name='campusView'),
+    url(
+        r'^collections/themed/$',
+        RedirectView.as_view(url='/exhibitions/'),
+        name='themedCollections'),
+    url(
+        r'^collections/cal-cultures/$',
+        RedirectView.as_view(url='/cal-cultures/'),
+        name='calCultures'),
+    url(
+        r'^collections/jarda/$',
+        RedirectView.as_view(url='/exhibitions/t11/jarda/'),
+        name='jarda'),
+    url(
+        r'^collections/titleSearch/$',
+        views.collectionsSearch,
+        name='collectionsTitleSearch'),
+    url(
+        r'^collections/titles.json$',
+        views.collectionsTitles,
+        name='collectionsTitleData'),
+    url(
+        r'^institution/(?P<repository_id>\d*)(?:/(?P<subnav>items|collections))?/',
+        views.repositoryView,
+        name='repositoryView'),
+    url(
+        r'^(?P<campus_slug>UC\w{1,2})(?:/(?P<subnav>items|collections|institutions))?/',
+        views.campusView,
+        name='campusView'),
     url(r'^institutions/$', views.campusDirectory, name='campusDirectory'),
-    url(r'^institutions/statewide-partners/$', views.statewideDirectory, name='statewideDirectory'),
-
-    url(r'about/$', TemplateView.as_view(template_name='calisphere/about.html'), name='about'),
-    url(r'help/$', TemplateView.as_view(template_name='calisphere/help.html'), name='help'),
-    url(r'terms/$', TemplateView.as_view(template_name='calisphere/termsOfUse.html'), name='termsOfUse'),
-    url(r'privacy/$', TemplateView.as_view(template_name='calisphere/privacyStatement.html'), name='privacyStatement'),
-    url(r'outreach/$', TemplateView.as_view(template_name='calisphere/outreach.html'), name='outreach'),
-    url(r'contribute/$', TemplateView.as_view(template_name='calisphere/contribute.html'), name='contribute'),
-    url(r'jobs/$', TemplateView.as_view(template_name='calisphere/jobs.html'), name='jobs'),
+    url(
+        r'^institutions/statewide-partners/$',
+        views.statewideDirectory,
+        name='statewideDirectory'),
+    url(
+        r'about/$',
+        TemplateView.as_view(template_name='calisphere/about.html'),
+        name='about'),
+    url(
+        r'help/$',
+        TemplateView.as_view(template_name='calisphere/help.html'),
+        name='help'),
+    url(
+        r'terms/$',
+        TemplateView.as_view(template_name='calisphere/termsOfUse.html'),
+        name='termsOfUse'),
+    url(
+        r'privacy/$',
+        TemplateView.as_view(template_name='calisphere/privacyStatement.html'),
+        name='privacyStatement'),
+    url(
+        r'outreach/$',
+        TemplateView.as_view(template_name='calisphere/outreach.html'),
+        name='outreach'),
+    url(
+        r'contribute/$',
+        TemplateView.as_view(template_name='calisphere/contribute.html'),
+        name='contribute'),
+    url(
+        r'jobs/$',
+        TemplateView.as_view(template_name='calisphere/jobs.html'),
+        name='jobs'),
     url(r'posters/$', views.posters, name='posters'),
     url(r'sitemap-(?P<section>.*).xml$', views.sitemapSection),
     url(r'sitemap-(?P<section>.*).xml.gz$', views.sitemapSectionZipped),
 
     # AJAX HELPERS
-    url(r'^relatedCollections/', views.relatedCollections, name='relatedCollections'),
+    url(
+        r'^relatedCollections/',
+        views.relatedCollections,
+        name='relatedCollections'),
     url(r'^carousel/', views.itemViewCarousel, name='carousel'),
     url(r'^contactOwner/', views.contactOwner, name='contactOwner'),
 ]

--- a/calisphere/views.py
+++ b/calisphere/views.py
@@ -19,11 +19,13 @@ import simplejson as json
 import string
 import urlparse
 
+
 # concat query with 'AND'
 def concat_query(q, rq):
     if q == '': return rq
     elif rq == '': return q
     else: return q + ' AND ' + rq
+
 
 # concat filters with 'OR'
 def concat_filters(filters, filter_type):
@@ -33,19 +35,22 @@ def concat_filters(filters, filter_type):
     for counter, f in enumerate(filters):
         fq_contents = fq_contents + '"' + f + '"'
         # if not at the last filter term, continue OR-ing together terms
-        if counter < len(filters)-1:
+        if counter < len(filters) - 1:
             fq_contents = fq_contents + " OR " + filter_type + ': '
 
     return [fq_contents]
 
+
 # collect filters into an array
 def solrize_filters(filters):
     fq = []
-    for filter_type in list(facet_filter_type['filter'] for facet_filter_type in FACET_FILTER_TYPES):
+    for filter_type in list(facet_filter_type['filter']
+                            for facet_filter_type in FACET_FILTER_TYPES):
         if len(filters[filter_type]) > 0:
             fq.extend(concat_filters(filters[filter_type], filter_type))
 
     return fq
+
 
 def solrize_sort(sort):
     # return 'score desc'
@@ -66,6 +71,7 @@ def solrize_sort(sort):
     else:
         return 'score desc'
 
+
 def process_sort_collection_data(string):
     '''temporary; should parse sort_collection_data
        with either `:` or `::` dlimiter style
@@ -77,17 +83,17 @@ def process_sort_collection_data(string):
         part2, part3 = remainder.rsplit(':https:')
         return [part1, part2, 'https:{}'.format(part3)]
 
+
 def getMoreCollectionData(collection_data):
     collection = getCollectionData(
         collection_data=collection_data,
-        collection_id=None,
-    )
+        collection_id=None, )
     collection_details = json_loads_url(
-        "{0}?format=json".format(collection['url'])
-    )
+        "{0}?format=json".format(collection['url']))
     collection['local_id'] = collection_details['local_id']
     collection['slug'] = collection_details['slug']
     return collection
+
 
 def getCollectionData(collection_data=None, collection_id=None):
     collection = {}
@@ -95,21 +101,29 @@ def getCollectionData(collection_data=None, collection_id=None):
         parts = collection_data.split('::')
         collection['url'] = parts[0] if len(parts) >= 1 else ''
         collection['name'] = parts[1] if len(parts) >= 2 else ''
-        collection_api_url = re.match(r'^https://registry\.cdlib\.org/api/v1/collection/(?P<url>\d*)/?', collection['url'])
+        collection_api_url = re.match(
+            r'^https://registry\.cdlib\.org/api/v1/collection/(?P<url>\d*)/?',
+            collection['url'])
         if collection_api_url is None:
             print('no collection api url:')
             collection['id'] = ''
         else:
             collection['id'] = collection_api_url.group('url')
     elif collection_id:
-        solr_collections = CollectionManager(settings.SOLR_URL, settings.SOLR_API_KEY)
-        collection['url'] = "https://registry.cdlib.org/api/v1/collection/{0}/".format(collection_id)
+        solr_collections = CollectionManager(settings.SOLR_URL,
+                                             settings.SOLR_API_KEY)
+        collection[
+            'url'] = "https://registry.cdlib.org/api/v1/collection/{0}/".format(
+                collection_id)
         collection['id'] = collection_id
-        collection_details = json_loads_url("{0}?format=json".format(collection['url']))
-        collection['name'] = solr_collections.names.get(collection['url']) or collection_details['name']
+        collection_details = json_loads_url(
+            "{0}?format=json".format(collection['url']))
+        collection['name'] = solr_collections.names.get(
+            collection['url']) or collection_details['name']
         collection['local_id'] = collection_details['local_id']
         collection['slug'] = collection_details['slug']
     return collection
+
 
 def getCollectionMosaic(collection_url):
     collection_details = json_loads_url(collection_url + "?format=json")
@@ -123,32 +137,40 @@ def getCollectionMosaic(collection_url):
 
     for repository in repository_details:
         if 'campus' in repository and len(repository['campus']) > 0:
-            collection_repositories.append(repository['campus'][0]['name'] + ", " + repository['name'])
+            collection_repositories.append(repository['campus'][0]['name'] +
+                                           ", " + repository['name'])
         else:
             collection_repositories.append(repository['name'])
 
-    collection_api_url = re.match(r'^https://registry\.cdlib\.org/api/v1/collection/(?P<url>\d*)/?', collection_url)
+    collection_api_url = re.match(
+        r'^https://registry\.cdlib\.org/api/v1/collection/(?P<url>\d*)/?',
+        collection_url)
     collection_id = collection_api_url.group('url')
 
     display_items = SOLR_select(
         q='*:*',
-        fields='reference_image_md5, url_item, id, title, collection_url, type_ss',
+        fields=
+        'reference_image_md5, url_item, id, title, collection_url, type_ss',
         sort=solrize_sort('a'),
         rows=6,
         start=0,
-        fq=['collection_url: \"' + collection_url + '\"', 'type_ss: \"image\"']
-    )
+        fq=[
+            'collection_url: \"' + collection_url + '\"', 'type_ss: \"image\"'
+        ])
 
     items = display_items.results
 
     ugly_display_items = SOLR_select(
         q='*:*',
-        fields='reference_image_md5, url_item, id, title, collection_url, type_ss',
+        fields=
+        'reference_image_md5, url_item, id, title, collection_url, type_ss',
         sort=solrize_sort('a'),
         rows=6,
         start=0,
-        fq=['collection_url: \"' + collection_url + '\"', '(*:* AND -type_ss:\"image\")']
-    )
+        fq=[
+            'collection_url: \"' + collection_url + '\"',
+            '(*:* AND -type_ss:\"image\")'
+        ])
 
     if len(display_items.results) < 6:
         items = items + ugly_display_items.results
@@ -162,15 +184,20 @@ def getCollectionMosaic(collection_url):
         'display_items': items
     }
 
-def getRepositoryData(repository_data=None, repository_id=None, repository_url=None):
+
+def getRepositoryData(repository_data=None,
+                      repository_id=None,
+                      repository_url=None):
     """ supply either `repository_data` from solr or the `repository_id` or `repository_url`
         all the reset will be looked up and filled in
     """
     app = apps.get_app_config('calisphere')
     repository = {}
     repository_details = {}
-    if not(repository_data) and not(repository_id) and repository_url:
-        repository_id = re.match(r'https://registry\.cdlib\.org/api/v1/repository/(?P<repository_id>\d*)/?', repository_url).group('repository_id')
+    if not (repository_data) and not (repository_id) and repository_url:
+        repository_id = re.match(
+            r'https://registry\.cdlib\.org/api/v1/repository/(?P<repository_id>\d*)/?',
+            repository_url).group('repository_id')
     if repository_data:
         parts = repository_data.split('::')
         repository['url'] = parts[0] if len(parts) >= 1 else ''
@@ -179,27 +206,29 @@ def getRepositoryData(repository_data=None, repository_id=None, repository_url=N
 
         repository_api_url = re.match(
             r'^https://registry\.cdlib\.org/api/v1/repository/(?P<url>\d*)/',
-            repository['url']
-        )
+            repository['url'])
         if repository_api_url is None:
             print('no repository api url')
             repository['id'] = ''
         else:
             repository['id'] = repository_api_url.group('url')
             repository_details = app.registry.repository_data.get(
-                int(repository['id']), {}
-            )
+                int(repository['id']), {})
     elif repository_id:
-        repository['url'] = "https://registry.cdlib.org/api/v1/repository/{0}/".format(repository_id)
+        repository[
+            'url'] = "https://registry.cdlib.org/api/v1/repository/{0}/".format(
+                repository_id)
         repository['id'] = repository_id
-        repository_details = app.registry.repository_data.get(int(repository_id), None)
+        repository_details = app.registry.repository_data.get(
+            int(repository_id), None)
         repository['name'] = repository_details['name']
         if repository_details['campus']:
             repository['campus'] = repository_details['campus'][0]['name']
         else:
             repository['campus'] = ''
     # details needed for stats
-    repository['ga_code'] = repository_details.get('google_analytics_tracking_code', None)
+    repository['ga_code'] = repository_details.get(
+        'google_analytics_tracking_code', None)
     parent = repository_details['campus']
     pslug = ''
     if len(parent):
@@ -207,33 +236,47 @@ def getRepositoryData(repository_data=None, repository_id=None, repository_url=N
     repository['slug'] = pslug + repository_details.get('slug', None)
     return repository
 
+
 def process_facets(facets, filters, facet_type=None):
-    display_facets = dict((facet, count) for facet, count in facets.iteritems() if count != 0)
+    display_facets = dict((facet, count)
+                          for facet, count in facets.iteritems() if count != 0)
     if facet_type and facet_type == 'facet_decade':
-        display_facets = sorted(display_facets.iteritems(), key=operator.itemgetter(0))
+        display_facets = sorted(
+            display_facets.iteritems(), key=operator.itemgetter(0))
     else:
-        display_facets = sorted(display_facets.iteritems(), key=operator.itemgetter(1), reverse=True)
+        display_facets = sorted(
+            display_facets.iteritems(),
+            key=operator.itemgetter(1),
+            reverse=True)
 
     for f in filters:
         if not any(f in facet[0] for facet in display_facets):
-            api_url = re.match(r'^https://registry\.cdlib\.org/api/v1/(?P<collection_or_repo>collection|repository)/(?P<url>\d*)/?', f)
+            api_url = re.match(
+                r'^https://registry\.cdlib\.org/api/v1/(?P<collection_or_repo>collection|repository)/(?P<url>\d*)/?',
+                f)
             if api_url is not None:
                 if api_url.group('collection_or_repo') == 'collection':
-                    collection = getCollectionData(collection_id=api_url.group('url'))
-                    display_facets.append((collection['url'] + "::" + collection['name'], 0))
+                    collection = getCollectionData(
+                        collection_id=api_url.group('url'))
+                    display_facets.append(
+                        (collection['url'] + "::" + collection['name'], 0))
                 elif api_url.group('collection_or_repo') == 'repository':
-                    repository = getRepositoryData(repository_id=api_url.group('url'))
-                    display_facets.append((repository['url'] + "::" + repository['name'], 0))
+                    repository = getRepositoryData(
+                        repository_id=api_url.group('url'))
+                    display_facets.append(
+                        (repository['url'] + "::" + repository['name'], 0))
             else:
                 display_facets.append((f, 0))
 
     return display_facets
+
 
 def filterType(facet_type):
     for facet_filter_type in FACET_FILTER_TYPES:
         if (facet_filter_type['facet'] == facet_type):
             return facet_filter_type['filter']
     return None
+
 
 def facetQuery(facet_fields, queryParams, solr_search, extra_filter=None):
     facets = {}
@@ -243,10 +286,14 @@ def facetQuery(facet_fields, queryParams, solr_search, extra_filter=None):
         # used to obtain counts - since we AND filters of the same type, counts should go UP when more than one facet is selected
         # as a filter, not DOWN (or'ed filters of the same type)
         filter_type = filterType(facet_type)
-        if filter_type in queryParams['filters'] and len(queryParams['filters'][filter_type]) > 0:
+        if filter_type in queryParams['filters'] and len(
+                queryParams['filters'][filter_type]) > 0:
             # other_filters is all the filters except the ones of the current filter type
-            other_filters = {key: value for key, value in queryParams['filters'].items()
-                if key != filter_type}
+            other_filters = {
+                key: value
+                for key, value in queryParams['filters'].items()
+                if key != filter_type
+            }
             other_filters[filter_type] = []
 
             fq = solrize_filters(other_filters)
@@ -262,21 +309,18 @@ def facetQuery(facet_fields, queryParams, solr_search, extra_filter=None):
                 facet='true',
                 facet_mincount=1,
                 facet_limit='-1',
-                facet_field=[facet_type]
-            )
+                facet_field=[facet_type])
             facets[facet_type] = process_facets(
                 facet_solr_search.facet_counts['facet_fields'][facet_type],
-                queryParams['filters'][filter_type],
-                facet_type
-            )
+                queryParams['filters'][filter_type], facet_type)
         else:
             facets[facet_type] = process_facets(
                 solr_search.facet_counts['facet_fields'][facet_type],
-                queryParams['filters'][filter_type] if filter_type in queryParams['filters'] else [],
-                facet_type
-            )
+                queryParams['filters'][filter_type]
+                if filter_type in queryParams['filters'] else [], facet_type)
 
     return facets
+
 
 def processQueryRequest(request):
     # concatenate query terms from refine query and query box, set defaults
@@ -285,9 +329,7 @@ def processQueryRequest(request):
     query_terms = ''
     if q or rq:
         query_terms = reduce(
-            concat_query,
-            request.GET.getlist('q') + request.GET.getlist('rq')
-        )
+            concat_query, request.GET.getlist('q') + request.GET.getlist('rq'))
     rows = request.GET.get('rows', '24')
     start = request.GET.get('start', '0')
     try:
@@ -309,13 +351,9 @@ def processQueryRequest(request):
     # in the list FACET_FILTER_TYPES create a dictionary with key filter_solr_name of filter
     # and value list of selected parameters for that filter
     # {'type': ['image', 'audio'], 'repository_name': [...]}
-    filters = dict(
-        (
-            facet_filter_type['filter'],
-            request.GET.getlist(facet_filter_type['facet'])
-        )
-        for facet_filter_type in FACET_FILTER_TYPES
-    )
+    filters = dict((facet_filter_type['filter'],
+                    request.GET.getlist(facet_filter_type['facet']))
+                   for facet_filter_type in FACET_FILTER_TYPES)
     # use collection_id and repository_id to retrieve collection_data
     # and repository_data filter values
     collection_template = "https://registry.cdlib.org/api/v1/collection/{0}/"
@@ -338,25 +376,33 @@ def processQueryRequest(request):
         'campus_slug': campus_slug
     }
 
+
 def home(request):
-    return render (request, 'calisphere/home.html', {'q': ''})
+    return render(request, 'calisphere/home.html', {'q': ''})
+
 
 def getHostedContentFile(structmap):
     contentFile = ''
     if structmap['format'] == 'image':
-        structmap_url = '{}{}/info.json'.format(
-            settings.UCLDC_IIIF,
-            structmap['id']
-        )
+        structmap_url = '{}{}/info.json'.format(settings.UCLDC_IIIF,
+                                                structmap['id'])
         if structmap_url.startswith('//'):
             structmap_url = ''.join(['http:', structmap_url])
         size = json_loads_url(structmap_url)['sizes'][-1]
         if size['height'] > size['width']:
-            access_size = {'width': ((size['width'] * 1024) / size['height']), 'height': 1024}
-            access_url = json_loads_url(structmap_url)['@id'] + "/full/,1024/0/default.jpg"
+            access_size = {
+                'width': ((size['width'] * 1024) / size['height']),
+                'height': 1024
+            }
+            access_url = json_loads_url(
+                structmap_url)['@id'] + "/full/,1024/0/default.jpg"
         else:
-            access_size = {'width': 1024, 'height': ((size['height'] * 1024) / size['width'])}
-            access_url = json_loads_url(structmap_url)['@id'] + "/full/1024,/0/default.jpg"
+            access_size = {
+                'width': 1024,
+                'height': ((size['height'] * 1024) / size['width'])
+            }
+            access_url = json_loads_url(
+                structmap_url)['@id'] + "/full/1024,/0/default.jpg"
 
         contentFile = {
             'titleSources': json.dumps(json_loads_url(structmap_url)),
@@ -386,6 +432,7 @@ def getHostedContentFile(structmap):
 
     return contentFile
 
+
 def itemView(request, item_id=''):
     item_id_search_term = 'id:"{0}"'.format(item_id)
     item_solr_search = SOLR_select(q=item_id_search_term)
@@ -393,16 +440,21 @@ def itemView(request, item_id=''):
         # second level search
         def _fixid(id):
             return re.sub(r'^(\d*--http:/)(?!/)', r'\1/', id)
-        old_id_search = SOLR_select(q='harvest_id_s:*{}'.format(_fixid(item_id)))
+
+        old_id_search = SOLR_select(
+            q='harvest_id_s:*{}'.format(_fixid(item_id)))
         if old_id_search.numFound:
-            return redirect('calisphere:itemView', old_id_search.results[0]['id'])
+            return redirect('calisphere:itemView',
+                            old_id_search.results[0]['id'])
         else:
             raise Http404("{0} does not exist".format(item_id))
 
     for item in item_solr_search.results:
         if 'structmap_url' in item and len(item['structmap_url']) >= 1:
             item['harvest_type'] = 'hosted'
-            structmap_url = string.replace(item['structmap_url'], 's3://static', 'https://s3.amazonaws.com/static');
+            structmap_url = string.replace(item['structmap_url'],
+                                           's3://static',
+                                           'https://s3.amazonaws.com/static')
             structmap_data = json_loads_url(structmap_url)
 
             item['format'] = structmap_data.get('format', '')
@@ -419,17 +471,20 @@ def itemView(request, item_id=''):
                     if 'format' in component:
                         item['contentFile'] = getHostedContentFile(component)
                     # remove emptry strings from list
-                    for k,v in component.iteritems():
+                    for k, v in component.iteritems():
                         if isinstance(v, list):
                             if isinstance(v[0], unicode):
-                                component[k] = filter(lambda name: name.strip(), v)
+                                component[k] = filter(
+                                    lambda name: name.strip(), v)
                     # remove empty lists and empty strings from dict
-                    item['selectedComponent'] = dict((k, v) for k, v in component.iteritems() if v)
+                    item['selectedComponent'] = dict(
+                        (k, v) for k, v in component.iteritems() if v)
                 else:
                     item['selected'] = True
                     # if parent content file, get it
                     if 'format' in structmap_data and structmap_data['format'] != 'file':
-                        item['contentFile'] = getHostedContentFile(structmap_data)
+                        item['contentFile'] = getHostedContentFile(
+                            structmap_data)
                     # otherwise get first component file
                     else:
                         component = structmap_data['structMap'][0]
@@ -437,7 +492,11 @@ def itemView(request, item_id=''):
                 item['structMap'] = structmap_data['structMap']
 
                 # single or multi-format object
-                formats = [component['format'] for component in structmap_data['structMap'] if 'format' in component]
+                formats = [
+                    component['format']
+                    for component in structmap_data['structMap']
+                    if 'format' in component
+                ]
                 if len(set(formats)) > 1:
                     item['multiFormat'] = True
                 else:
@@ -466,7 +525,9 @@ def itemView(request, item_id=''):
             if 'url_item' in item:
                 if item['url_item'].startswith('http://ark.cdlib.org/ark:'):
                     item['oac'] = True
-                    item['url_item'] = string.replace(item['url_item'], 'http://ark.cdlib.org/ark:', 'http://oac.cdlib.org/ark:')
+                    item['url_item'] = string.replace(
+                        item['url_item'], 'http://ark.cdlib.org/ark:',
+                        'http://oac.cdlib.org/ark:')
                     item['url_item'] = item['url_item'] + '/?brand=oac4'
                 else:
                     item['oac'] = False
@@ -476,15 +537,20 @@ def itemView(request, item_id=''):
         item['parsed_repository_data'] = []
         item['institution_contact'] = []
         for collection_data in item['collection_data']:
-            item['parsed_collection_data'].append(getMoreCollectionData(collection_data))
+            item['parsed_collection_data'].append(
+                getMoreCollectionData(collection_data))
         if 'repository_data' in item:
             for repository_data in item['repository_data']:
-                item['parsed_repository_data'].append(getRepositoryData(repository_data=repository_data))
+                item['parsed_repository_data'].append(
+                    getRepositoryData(repository_data=repository_data))
 
                 institution_url = item['parsed_repository_data'][0]['url']
-                institution_details = json_loads_url(institution_url + "?format=json")
+                institution_details = json_loads_url(institution_url +
+                                                     "?format=json")
                 if 'ark' in institution_details and institution_details['ark'] != '':
-                    contact_information = json_loads_url("http://dsc.cdlib.org/institution-json/" + institution_details['ark'])
+                    contact_information = json_loads_url(
+                        "http://dsc.cdlib.org/institution-json/" +
+                        institution_details['ark'])
                 else:
                     contact_information = ''
 
@@ -494,18 +560,18 @@ def itemView(request, item_id=''):
     if item_solr_search.results[0].get('reference_image_md5', False):
         meta_image = urlparse.urljoin(
             settings.UCLDC_FRONT,
-            '/crop/999x999/{0}'.format(item_solr_search.results[0]['reference_image_md5']),
-        )
+            '/crop/999x999/{0}'.format(
+                item_solr_search.results[0]['reference_image_md5']), )
 
     fromItemPage = request.META.get("HTTP_X_FROM_ITEM_PAGE")
     if fromItemPage:
-        return render (request, 'calisphere/itemViewer.html', {
+        return render(request, 'calisphere/itemViewer.html', {
             'q': '',
             'item': item_solr_search.results[0],
             'item_solr_search': item_solr_search,
             'meta_image': meta_image,
         })
-    search_results = { 'reference_image_md5': None }
+    search_results = {'reference_image_md5': None}
     search_results.update(item_solr_search.results[0])
     return render(request, 'calisphere/itemView.html', {
         'q': '',
@@ -526,7 +592,8 @@ def search(request):
         queryParams = processQueryRequest(request)
 
         # define facet fields to retrieve
-        facet_fields = list(facet_filter_type['facet'] for facet_filter_type in FACET_FILTER_TYPES)
+        facet_fields = list(facet_filter_type['facet']
+                            for facet_filter_type in FACET_FILTER_TYPES)
 
         solr_search = SOLR_select(
             q=queryParams['query_terms'],
@@ -537,8 +604,7 @@ def search(request):
             facet='true',
             facet_mincount=1,
             facet_limit='-1',
-            facet_field=facet_fields
-        )
+            facet_field=facet_fields)
 
         # TODO: create a no results found page
         if len(solr_search.results) == 0: print('no results found')
@@ -547,10 +613,12 @@ def search(request):
         facets = facetQuery(facet_fields, queryParams, solr_search)
 
         for i, facet_item in enumerate(facets['collection_data']):
-            collection = (getCollectionData(collection_data=facet_item[0]), facet_item[1])
+            collection = (getCollectionData(collection_data=facet_item[0]),
+                          facet_item[1])
             facets['collection_data'][i] = collection
         for i, facet_item in enumerate(facets['repository_data']):
-            repository = (getRepositoryData(repository_data=facet_item[0]), facet_item[1])
+            repository = (getRepositoryData(repository_data=facet_item[0]),
+                          facet_item[1])
             facets['repository_data'][i] = repository
 
         filter_display = {}
@@ -558,43 +626,71 @@ def search(request):
             if filter_type == 'collection_url':
                 filter_display['collection_url'] = []
                 for filter_item in queryParams['filters'][filter_type]:
-                    collection_api_url = re.match(r'^https://registry\.cdlib\.org/api/v1/collection/(?P<url>\d*)/?', filter_item)
+                    collection_api_url = re.match(
+                        r'^https://registry\.cdlib\.org/api/v1/collection/(?P<url>\d*)/?',
+                        filter_item)
                     if collection_api_url is not None:
-                        collection = getCollectionData(collection_id=collection_api_url.group('url'))
+                        collection = getCollectionData(
+                            collection_id=collection_api_url.group('url'))
                         collection.pop('local_id', None)
                         collection.pop('slug', None)
                         filter_display['collection_url'].append(collection)
             elif filter_type == 'repository_url':
                 filter_display['repository_url'] = []
                 for filter_item in queryParams['filters'][filter_type]:
-                    repository_api_url = re.match(r'^https://registry\.cdlib\.org/api/v1/repository/(?P<url>\d*)/', filter_item)
+                    repository_api_url = re.match(
+                        r'^https://registry\.cdlib\.org/api/v1/repository/(?P<url>\d*)/',
+                        filter_item)
                     if repository_api_url is not None:
-                        repository = getRepositoryData(repository_id=repository_api_url.group('url'))
+                        repository = getRepositoryData(
+                            repository_id=repository_api_url.group('url'))
                         repository.pop('local_id', None)
                         filter_display['repository_url'].append(repository)
             else:
-                filter_display[filter_type] = copy.copy(queryParams['filters'][filter_type])
+                filter_display[filter_type] = copy.copy(
+                    queryParams['filters'][filter_type])
 
         return render(request, 'calisphere/searchResults.html', {
-            'q': queryParams['q'],
-            'rq': queryParams['rq'],
-            'filters': filter_display,
-            'rows': queryParams['rows'],
-            'start': queryParams['start'],
-            'sort': queryParams['sort'],
-            'search_results': solr_search.results,
-            'facets': facets,
-            'FACET_FILTER_TYPES': FACET_FILTER_TYPES,
-            'numFound': solr_search.numFound,
-            'pages': int(math.ceil(float(solr_search.numFound)/int(queryParams['rows']))),
-            'view_format': queryParams['view_format'],
-            'related_collections': relatedCollections(request, queryParams),
-            'num_related_collections': len(queryParams['filters']['collection_url']) if len(queryParams['filters']['collection_url']) > 0 else len(facets['collection_data']),
-            'rc_page': queryParams['rc_page'],
-            'form_action': reverse('calisphere:search')
+            'q':
+            queryParams['q'],
+            'rq':
+            queryParams['rq'],
+            'filters':
+            filter_display,
+            'rows':
+            queryParams['rows'],
+            'start':
+            queryParams['start'],
+            'sort':
+            queryParams['sort'],
+            'search_results':
+            solr_search.results,
+            'facets':
+            facets,
+            'FACET_FILTER_TYPES':
+            FACET_FILTER_TYPES,
+            'numFound':
+            solr_search.numFound,
+            'pages':
+            int(
+                math.ceil(
+                    float(solr_search.numFound) / int(queryParams['rows']))),
+            'view_format':
+            queryParams['view_format'],
+            'related_collections':
+            relatedCollections(request, queryParams),
+            'num_related_collections':
+            len(queryParams['filters']['collection_url'])
+            if len(queryParams['filters']['collection_url']) > 0 else
+            len(facets['collection_data']),
+            'rc_page':
+            queryParams['rc_page'],
+            'form_action':
+            reverse('calisphere:search')
         })
 
     return redirect('calisphere:home')
+
 
 def itemViewCarousel(request):
     item_id = request.GET.get('itemId')
@@ -621,25 +717,27 @@ def itemViewCarousel(request):
         if campus_id == '':
             raise Http404("Campus registry ID not found")
 
-        fq.append('campus_url: "https://registry.cdlib.org/api/v1/campus/' + campus_id + '/"')
+        fq.append('campus_url: "https://registry.cdlib.org/api/v1/campus/' +
+                  campus_id + '/"')
 
     mlt = False
     if queryParams['q'] == '' and len(fq) == 0:
-        mlt=True,
-        mlt_fl='title,collection_name,subject'
+        mlt = True,
+        mlt_fl = 'title,collection_name,subject'
 
     if mlt:
         carousel_solr_search = SOLR_raw(
-            q='id:'+item_id,
+            q='id:' + item_id,
             fields='id, type_ss, reference_image_md5, title',
             mlt='true',
             mlt_count='24',
             mlt_fl=mlt_fl,
-            mlt_mintf=1,
-        )
+            mlt_mintf=1, )
         if json.loads(carousel_solr_search)['response']['numFound'] == 0:
             raise Http404('No object with id "' + item_id + '" found.')
-        search_results = json.loads(carousel_solr_search)['response']['docs'] + json.loads(carousel_solr_search)['moreLikeThis'][item_id]['docs']
+        search_results = json.loads(
+            carousel_solr_search)['response']['docs'] + json.loads(
+                carousel_solr_search)['moreLikeThis'][item_id]['docs']
         numFound = len(search_results)
         # numFound = json.loads(carousel_solr_search)['moreLikeThis'][item_id]['numFound']
     else:
@@ -649,8 +747,7 @@ def itemViewCarousel(request):
             rows=queryParams['rows'],
             start=queryParams['start'],
             sort=solrize_sort(queryParams['sort']),
-            fq=fq
-        )
+            fq=fq)
         search_results = carousel_solr_search.results
         numFound = carousel_solr_search.numFound
 
@@ -660,21 +757,28 @@ def itemViewCarousel(request):
             if filter_type == 'collection_url':
                 filter_display['collection_url'] = []
                 for filter_item in queryParams['filters'][filter_type]:
-                    collection_api_url = re.match(r'^https://registry\.cdlib\.org/api/v1/collection/(?P<url>\d*)/?', filter_item)
+                    collection_api_url = re.match(
+                        r'^https://registry\.cdlib\.org/api/v1/collection/(?P<url>\d*)/?',
+                        filter_item)
                     if collection_api_url is not None:
-                        collection = getCollectionData(collection_id=collection_api_url.group('url'))
+                        collection = getCollectionData(
+                            collection_id=collection_api_url.group('url'))
                         collection.pop('local_id', None)
                         filter_display['collection_url'].append(collection)
             elif filter_type == 'repository_url':
                 filter_display['repository_url'] = []
                 for filter_item in queryParams['filters'][filter_type]:
-                    repository_api_url = re.match(r'^https://registry\.cdlib\.org/api/v1/repository/(?P<url>\d*)/', filter_item)
+                    repository_api_url = re.match(
+                        r'^https://registry\.cdlib\.org/api/v1/repository/(?P<url>\d*)/',
+                        filter_item)
                     if repository_api_url is not None:
-                        repository = getRepositoryData(repository_id=repository_api_url.group('url'))
+                        repository = getRepositoryData(
+                            repository_id=repository_api_url.group('url'))
                         repository.pop('local_id', None)
                         filter_display['repository_url'].append(repository)
             else:
-                filter_display[filter_type] = copy.copy(queryParams['filters'][filter_type])
+                filter_display[filter_type] = copy.copy(
+                    queryParams['filters'][filter_type])
 
         return render(request, 'calisphere/carouselContainer.html', {
             'q': queryParams['q'],
@@ -696,6 +800,7 @@ def itemViewCarousel(request):
             'search_results': search_results,
             'item_id': item_id
         })
+
 
 def relatedCollections(request, queryParams={}):
     if not queryParams:
@@ -724,7 +829,8 @@ def relatedCollections(request, queryParams={}):
         if campus_id == '':
             print('Campus registry ID not found')
 
-        fq.append('campus_url: "https://registry.cdlib.org/api/v1/campus/' + campus_id + '/"')
+        fq.append('campus_url: "https://registry.cdlib.org/api/v1/campus/' +
+                  campus_id + '/"')
 
     related_collections_solr_search = SOLR_select(
         q=queryParams['query_terms'],
@@ -733,54 +839,77 @@ def relatedCollections(request, queryParams={}):
         facet='true',
         facet_mincount=1,
         facet_limit='-1',
-        facet_field=['collection_data']
-    )
+        facet_field=['collection_data'])
 
     # remove collections with a count of 0 and sort by count
     related_collections_counts = process_facets(
-        related_collections_solr_search.facet_counts['facet_fields']['collection_data'],
-        queryParams['filters']['collection_url'] if 'collection_url' in queryParams['filters'] else []
-    )
+        related_collections_solr_search.facet_counts['facet_fields'][
+            'collection_data'], queryParams['filters']['collection_url']
+        if 'collection_url' in queryParams['filters'] else [])
 
     # remove 'count'
-    related_collections = list(facet for facet, count in related_collections_counts)
+    related_collections = list(facet
+                               for facet, count in related_collections_counts)
 
     three_related_collections = []
-    for i in range(queryParams['rc_page']*3, queryParams['rc_page']*3+3):
+    for i in range(queryParams['rc_page'] * 3, queryParams['rc_page'] * 3 + 3):
         if len(related_collections) > i:
-            facet = ["collection_url: \"" + getCollectionData(related_collections[i])['url'] + "\""]
-            collection_solr_search = SOLR_select(q=queryParams['query_terms'], rows='3', fq=facet, fields='collection_data, reference_image_md5, url_item, id, title, type_ss')
+            facet = [
+                "collection_url: \"" +
+                getCollectionData(related_collections[i])['url'] + "\""
+            ]
+            collection_solr_search = SOLR_select(
+                q=queryParams['query_terms'],
+                rows='3',
+                fq=facet,
+                fields=
+                'collection_data, reference_image_md5, url_item, id, title, type_ss'
+            )
 
             collection_items = collection_solr_search.results
             if len(collection_solr_search.results) < 3:
-                collection_solr_search_no_query = SOLR_select(q='', rows='3', fq=facet, fields='collection_data, reference_image_md5, url_item, id, title, type_ss')
+                collection_solr_search_no_query = SOLR_select(
+                    q='',
+                    rows='3',
+                    fq=facet,
+                    fields=
+                    'collection_data, reference_image_md5, url_item, id, title, type_ss'
+                )
                 #TODO: in some cases this will result in the same object appearing twice in the related collections preview
                 collection_items = collection_items + collection_solr_search_no_query.results
 
-            if len(collection_items) > 0 and len(collection_solr_search.results[0]) > 0:
-                if 'collection_data' in collection_solr_search.results[0] and len(collection_solr_search.results[0]['collection_data']) > 0:
-                    collection = collection_solr_search.results[0]['collection_data'][0]
+            if len(collection_items) > 0 and len(
+                    collection_solr_search.results[0]) > 0:
+                if 'collection_data' in collection_solr_search.results[0] and len(
+                        collection_solr_search.results[0]
+                    ['collection_data']) > 0:
+                    collection = collection_solr_search.results[0][
+                        'collection_data'][0]
 
                     collection_data = {'image_urls': []}
                     for item in collection_items:
                         collection_data['image_urls'].append(item)
 
-                    collection_url = ''.join([
-                        collection.rsplit('::')[0],
-                        '?format=json'
-                    ])
+                    collection_url = ''.join(
+                        [collection.rsplit('::')[0], '?format=json'])
                     collection_details = json_loads_url(collection_url)
 
                     collection_data['name'] = collection_details['name']
-                    collection_data['resource_uri'] = collection_details['resource_uri']
-                    col_id = re.match(r'^/api/v1/collection/(?P<collection_id>\d+)/$', collection_details['resource_uri'])
-                    collection_data['collection_id'] = col_id.group('collection_id')
+                    collection_data['resource_uri'] = collection_details[
+                        'resource_uri']
+                    col_id = re.match(
+                        r'^/api/v1/collection/(?P<collection_id>\d+)/$',
+                        collection_details['resource_uri'])
+                    collection_data['collection_id'] = col_id.group(
+                        'collection_id')
 
                     # TODO: get this from repository_data in solr rather than from the registry API
                     if collection_details['repository'][0]['campus']:
-                        collection_data['institution'] = collection_details['repository'][0]['campus'][0]['name'] + ', ' + collection_details['repository'][0]['name']
+                        collection_data[
+                            'institution'] = collection_details['repository'][0]['campus'][0]['name'] + ', ' + collection_details['repository'][0]['name']
                     else:
-                        collection_data['institution'] = collection_details['repository'][0]['name']
+                        collection_data['institution'] = collection_details[
+                            'repository'][0]['name']
 
                     three_related_collections.append(collection_data)
 
@@ -795,39 +924,51 @@ def relatedCollections(request, queryParams={}):
             'rc_page': queryParams.get('rc_page'),
         })
 
+
 def collectionsDirectory(request):
-    solr_collections = CollectionManager(settings.SOLR_URL, settings.SOLR_API_KEY)
+    solr_collections = CollectionManager(settings.SOLR_URL,
+                                         settings.SOLR_API_KEY)
     collections = []
 
     page = int(request.GET['page']) if 'page' in request.GET else 1
 
-    for collection_link in solr_collections.shuffled[(page-1)*10:page*10]:
+    for collection_link in solr_collections.shuffled[(page - 1) * 10:
+                                                     page * 10]:
         collections.append(getCollectionMosaic(collection_link.url))
 
-    context = {'collections': collections, 'random': True, 'pages': int(math.ceil(float(len(solr_collections.shuffled))/10))}
+    context = {
+        'collections': collections,
+        'random': True,
+        'pages': int(math.ceil(float(len(solr_collections.shuffled)) / 10))
+    }
 
-    if page*10 < len(solr_collections.shuffled):
-        context['next_page'] = page+1
-    if page-1 > 0:
-        context['prev_page'] = page-1
+    if page * 10 < len(solr_collections.shuffled):
+        context['next_page'] = page + 1
+    if page - 1 > 0:
+        context['prev_page'] = page - 1
 
     return render(request, 'calisphere/collectionsRandomExplore.html', context)
 
 
 def collectionsAZ(request, collection_letter):
-    solr_collections = CollectionManager(settings.SOLR_URL, settings.SOLR_API_KEY)
+    solr_collections = CollectionManager(settings.SOLR_URL,
+                                         settings.SOLR_API_KEY)
     collections_list = solr_collections.split[collection_letter.lower()]
 
     page = int(request.GET['page']) if 'page' in request.GET else 1
-    pages = int(math.ceil(float(len(collections_list))/10))
+    pages = int(math.ceil(float(len(collections_list)) / 10))
 
     collections = []
-    for collection_link in collections_list[(page-1)*10:page*10]:
+    for collection_link in collections_list[(page - 1) * 10:page * 10]:
         collections.append(getCollectionMosaic(collection_link.url))
 
-    alphabet = list((character, True if character.lower() not in solr_collections.no_collections else False) for character in list(string.ascii_uppercase))
+    alphabet = list(
+        (character, True if
+         character.lower() not in solr_collections.no_collections else False)
+        for character in list(string.ascii_uppercase))
 
-    context = {'collections': collections,
+    context = {
+        'collections': collections,
         'alphabet': alphabet,
         'collection_letter': collection_letter,
         'page': page,
@@ -835,10 +976,10 @@ def collectionsAZ(request, collection_letter):
         'random': None,
     }
 
-    if page*10 < len(collections_list):
-        context['next_page'] = page+1
-    if page-1 > 0:
-        context['prev_page'] = page-1
+    if page * 10 < len(collections_list):
+        context['next_page'] = page + 1
+    if page - 1 > 0:
+        context['prev_page'] = page - 1
 
     return render(request, 'calisphere/collectionsAZ.html', context)
 
@@ -846,22 +987,27 @@ def collectionsAZ(request, collection_letter):
 def collectionsTitles(request):
     '''create JSON/data for the collections search page'''
 
-
     def djangoize(uri):
         '''turn registry URI into URL on django site'''
-        collection_id = uri.split('https://registry.cdlib.org/api/v1/collection/',
-                                  1)[1][:-1]
-        return reverse('calisphere:collectionView',
-                       kwargs={'collection_id': collection_id})
-
+        collection_id = uri.split(
+            'https://registry.cdlib.org/api/v1/collection/', 1)[1][:-1]
+        return reverse(
+            'calisphere:collectionView',
+            kwargs={'collection_id': collection_id})
 
     collections = CollectionManager(settings.SOLR_URL, settings.SOLR_API_KEY)
-    data = [{ 'uri': djangoize(uri), 'title': title } for (uri, title) in collections.parsed]
+    data = [{
+        'uri': djangoize(uri),
+        'title': title
+    } for (uri, title) in collections.parsed]
     return JsonResponse(data, safe=False)
 
 
 def collectionsSearch(request):
-    return render(request, 'calisphere/collectionsTitleSearch.html', {'collections': [], 'collection_q': True})
+    return render(request, 'calisphere/collectionsTitleSearch.html',
+                  {'collections': [],
+                   'collection_q': True})
+
 
 def collectionView(request, collection_id):
     collection_url = 'https://registry.cdlib.org/api/v1/collection/' + collection_id + '/?format=json'
@@ -878,19 +1024,32 @@ def collectionView(request, collection_id):
     # Add Custom Facet Filter Types
     extra_facet_types = []
     if collection_details['custom_facet']:
-      for i in range(len(collection_details['custom_facet'])):
-        custom_facet = collection_details['custom_facet'][i]
-        extra_facet_types.append({'facet': custom_facet['facet_field'], 'display_name': custom_facet['label'], 'filter': custom_facet['facet_field']})
+        for i in range(len(collection_details['custom_facet'])):
+            custom_facet = collection_details['custom_facet'][i]
+            extra_facet_types.append({
+                'facet': custom_facet['facet_field'],
+                'display_name': custom_facet['label'],
+                'filter': custom_facet['facet_field']
+            })
 
-      # Add custom facet only if doesn't already exist.
-      [FACET_FILTER_TYPES.append(facet) for facet in extra_facet_types if facet not in FACET_FILTER_TYPES]
+        # Add custom facet only if doesn't already exist.
+        [
+            FACET_FILTER_TYPES.append(facet) for facet in extra_facet_types
+            if facet not in FACET_FILTER_TYPES
+        ]
 
     else:
-      # If collection_details['custom_facet'] is empty, remove extra facet types from FACET_FILTER_TYPES.
-      if len(FACET_FILTER_TYPES) > len(DEFAULT_FACET_FILTER_TYPES):
-        [FACET_FILTER_TYPES.remove(facet) for facet in FACET_FILTER_TYPES if facet not in DEFAULT_FACET_FILTER_TYPES]
+        # If collection_details['custom_facet'] is empty, remove extra facet types from FACET_FILTER_TYPES.
+        if len(FACET_FILTER_TYPES) > len(DEFAULT_FACET_FILTER_TYPES):
+            [
+                FACET_FILTER_TYPES.remove(facet)
+                for facet in FACET_FILTER_TYPES
+                if facet not in DEFAULT_FACET_FILTER_TYPES
+            ]
 
-    facet_fields = list(facet_filter_type['facet'] for facet_filter_type in FACET_FILTER_TYPES if facet_filter_type['facet'] != 'collection_data')
+    facet_fields = list(facet_filter_type['facet']
+                        for facet_filter_type in FACET_FILTER_TYPES
+                        if facet_filter_type['facet'] != 'collection_data')
 
     # perform the search
     solr_search = SOLR_select(
@@ -902,13 +1061,14 @@ def collectionView(request, collection_id):
         facet='true',
         facet_mincount=1,
         facet_limit='-1',
-        facet_field=facet_fields
-    )
+        facet_field=facet_fields)
 
-    facets = facetQuery(facet_fields, queryParams, solr_search, 'collection_url: "' + collection['url'] + '"')
+    facets = facetQuery(facet_fields, queryParams, solr_search,
+                        'collection_url: "' + collection['url'] + '"')
 
     for i, facet_item in enumerate(facets['repository_data']):
-        repository = (getRepositoryData(repository_data=facet_item[0]), facet_item[1])
+        repository = (getRepositoryData(repository_data=facet_item[0]),
+                      facet_item[1])
         facets['repository_data'][i] = repository
 
     filter_display = {}
@@ -918,70 +1078,119 @@ def collectionView(request, collection_id):
         elif filter_type == 'repository_url':
             filter_display['repository_url'] = []
             for filter_item in queryParams['filters'][filter_type]:
-                repository_api_url = re.match(r'^https://registry\.cdlib\.org/api/v1/repository/(?P<url>\d*)/', filter_item)
+                repository_api_url = re.match(
+                    r'^https://registry\.cdlib\.org/api/v1/repository/(?P<url>\d*)/',
+                    filter_item)
                 if repository_api_url is not None:
-                    repository = getRepositoryData(repository_id=repository_api_url.group('url'))
+                    repository = getRepositoryData(
+                        repository_id=repository_api_url.group('url'))
                     repository.pop('local_id', None)
                     filter_display['repository_url'].append(repository)
         else:
-            filter_display[filter_type] = copy.copy(queryParams['filters'][filter_type])
+            filter_display[filter_type] = copy.copy(
+                queryParams['filters'][filter_type])
 
     return render(request, 'calisphere/collectionView.html', {
-        'q': queryParams.get('q'),
-        'rq': queryParams.get('rq'),
-        'filters': filter_display,
-        'rows': queryParams.get('rows'),
-        'start': queryParams.get('start'),
-        'sort': queryParams.get('sort'),
-        'search_results': solr_search.results,
-        'facets': facets,
-        'FACET_FILTER_TYPES': list(facet_filter_type for facet_filter_type in FACET_FILTER_TYPES if facet_filter_type['facet'] != 'collection_data' and facet_filter_type['facet'] != 'repository_data'),
-        'numFound': solr_search.numFound,
-        'pages': int(math.ceil(float(solr_search.numFound)/int(queryParams['rows']))),
-        'view_format': queryParams.get('view_format'),
-        'collection': collection_details,
-        'collection_id': collection_id,
-        'form_action': reverse('calisphere:collectionView', kwargs={'collection_id': collection_id}),
+        'q':
+        queryParams.get('q'),
+        'rq':
+        queryParams.get('rq'),
+        'filters':
+        filter_display,
+        'rows':
+        queryParams.get('rows'),
+        'start':
+        queryParams.get('start'),
+        'sort':
+        queryParams.get('sort'),
+        'search_results':
+        solr_search.results,
+        'facets':
+        facets,
+        'FACET_FILTER_TYPES':
+        list(facet_filter_type for facet_filter_type in FACET_FILTER_TYPES
+             if facet_filter_type['facet'] != 'collection_data' and
+             facet_filter_type['facet'] != 'repository_data'),
+        'numFound':
+        solr_search.numFound,
+        'pages':
+        int(math.ceil(float(solr_search.numFound) / int(queryParams['rows']))),
+        'view_format':
+        queryParams.get('view_format'),
+        'collection':
+        collection_details,
+        'collection_id':
+        collection_id,
+        'form_action':
+        reverse(
+            'calisphere:collectionView',
+            kwargs={'collection_id': collection_id}),
     })
 
+
 def campusDirectory(request):
-    repositories_solr_query = SOLR_select(q='*:*', rows=0, start=0, facet='true', facet_mincount=1, facet_field=['repository_url'], facet_limit='-1')
-    solr_repositories = repositories_solr_query.facet_counts['facet_fields']['repository_url']
+    repositories_solr_query = SOLR_select(
+        q='*:*',
+        rows=0,
+        start=0,
+        facet='true',
+        facet_mincount=1,
+        facet_field=['repository_url'],
+        facet_limit='-1')
+    solr_repositories = repositories_solr_query.facet_counts['facet_fields'][
+        'repository_url']
 
     repositories = []
     for repository_url in solr_repositories:
         repository = getRepositoryData(repository_url=repository_url)
         if repository['campus']:
             repositories.append({
-                'name': repository['name'],
-                'campus': repository['campus'],
-                'repository_id': re.match(r'https://registry\.cdlib\.org/api/v1/repository/(?P<repository_id>\d*)/?', repository['url']).group('repository_id')
+                'name':
+                repository['name'],
+                'campus':
+                repository['campus'],
+                'repository_id':
+                re.match(
+                    r'https://registry\.cdlib\.org/api/v1/repository/(?P<repository_id>\d*)/?',
+                    repository['url']).group('repository_id')
             })
 
-    repositories = sorted(repositories, key=lambda repository: (repository['campus'], repository['name']))
+    repositories = sorted(
+        repositories,
+        key=lambda repository: (repository['campus'], repository['name']))
     # Use hard-coded campus list so UCLA ends up in the correct order
     # campuses = sorted(list(set([repository['campus'] for repository in repositories])))
 
-    return render(
-        request,
-        'calisphere/campusDirectory.html', {
-            'repositories': repositories,
-            'campuses': CAMPUS_LIST,
-            'state_repositories': None,
-            'description': None,
-        }
-    )
+    return render(request, 'calisphere/campusDirectory.html', {
+        'repositories': repositories,
+        'campuses': CAMPUS_LIST,
+        'state_repositories': None,
+        'description': None,
+    })
+
 
 def statewideDirectory(request):
-    repositories_solr_query = SOLR_select(q='*:*', rows=0, start=0, facet='true', facet_mincount=1, facet_field=['repository_url'], facet_limit='-1')
-    solr_repositories = repositories_solr_query.facet_counts['facet_fields']['repository_url']
+    repositories_solr_query = SOLR_select(
+        q='*:*',
+        rows=0,
+        start=0,
+        facet='true',
+        facet_mincount=1,
+        facet_field=['repository_url'],
+        facet_limit='-1')
+    solr_repositories = repositories_solr_query.facet_counts['facet_fields'][
+        'repository_url']
     repositories = []
     for repository_url in solr_repositories:
         repository = getRepositoryData(repository_url=repository_url)
         if repository['campus'] == '':
             repositories.append({
-                'name': repository['name'],
-                'repository_id': re.match(r'https://registry\.cdlib\.org/api/v1/repository/(?P<repository_id>\d*)/?', repository['url']).group('repository_id')
+                'name':
+                repository['name'],
+                'repository_id':
+                re.match(
+                    r'https://registry\.cdlib\.org/api/v1/repository/(?P<repository_id>\d*)/?',
+                    repository['url']).group('repository_id')
             })
 
     binned_repositories = []
@@ -1001,27 +1210,30 @@ def statewideDirectory(request):
             bin.sort()
             binned_repositories.append({char: bin})
 
-    return render(
-        request,
-        'calisphere/statewideDirectory.html', {
-            'state_repositories': binned_repositories,
-            'campuses': None,
-            'meta_image': None,
-            'description': None,
-            'q': None,
-        }
-    )
+    return render(request, 'calisphere/statewideDirectory.html', {
+        'state_repositories': binned_repositories,
+        'campuses': None,
+        'meta_image': None,
+        'description': None,
+        'q': None,
+    })
 
 
-def institutionView(request, institution_id, subnav=False, institution_type='repository|campus'):
+def institutionView(request,
+                    institution_id,
+                    subnav=False,
+                    institution_type='repository|campus'):
     institution_url = 'https://registry.cdlib.org/api/v1/' + institution_type + '/' + institution_id + '/'
     institution_details = json_loads_url(institution_url + "?format=json")
     if 'ark' in institution_details and institution_details['ark'] != '':
-        contact_information = json_loads_url("http://dsc.cdlib.org/institution-json/" + institution_details['ark'])
+        contact_information = json_loads_url(
+            "http://dsc.cdlib.org/institution-json/" +
+            institution_details['ark'])
     else:
         contact_information = ''
 
-    if 'campus' in institution_details and len(institution_details['campus']) > 0:
+    if 'campus' in institution_details and len(
+            institution_details['campus']) > 0:
         uc_institution = institution_details['campus']
     else:
         uc_institution = False
@@ -1032,12 +1244,16 @@ def institutionView(request, institution_id, subnav=False, institution_type='rep
 
         if institution_type == 'repository':
             fq.append('repository_url: "' + institution_url + '"')
-            facet_fields = list(facet_filter_type['facet'] for facet_filter_type in FACET_FILTER_TYPES if facet_filter_type['facet'] != 'repository_data')
+            facet_fields = list(
+                facet_filter_type['facet']
+                for facet_filter_type in FACET_FILTER_TYPES
+                if facet_filter_type['facet'] != 'repository_data')
 
         if institution_type == 'campus':
             queryParams['campus_slug'] = institution_details['slug']
             fq.append('campus_url: "' + institution_url + '"')
-            facet_fields = list(facet_filter_type['facet'] for facet_filter_type in FACET_FILTER_TYPES)
+            facet_fields = list(facet_filter_type['facet']
+                                for facet_filter_type in FACET_FILTER_TYPES)
 
         solr_search = SOLR_select(
             q=queryParams['query_terms'],
@@ -1048,23 +1264,26 @@ def institutionView(request, institution_id, subnav=False, institution_type='rep
             facet='true',
             facet_mincount=1,
             facet_limit='-1',
-            facet_field=facet_fields
-        )
+            facet_field=facet_fields)
 
         if institution_type == 'repository':
-            facets = facetQuery(facet_fields, queryParams, solr_search, 'repository_url: "' + institution_url + '"')
+            facets = facetQuery(facet_fields, queryParams, solr_search,
+                                'repository_url: "' + institution_url + '"')
         elif institution_type == 'campus':
-            facets = facetQuery(facet_fields, queryParams, solr_search, 'campus_url: "' + institution_url + '"')
+            facets = facetQuery(facet_fields, queryParams, solr_search,
+                                'campus_url: "' + institution_url + '"')
         else:
             facets = facetQuery(facet_fields, queryParams, solr_search)
 
         for i, facet_item in enumerate(facets['collection_data']):
-            collection = (getCollectionData(collection_data=facet_item[0]), facet_item[1])
+            collection = (getCollectionData(collection_data=facet_item[0]),
+                          facet_item[1])
             facets['collection_data'][i] = collection
 
         if institution_type == 'campus':
             for i, facet_item in enumerate(facets['repository_data']):
-                repository = (getRepositoryData(repository_data=facet_item[0]), facet_item[1])
+                repository = (getRepositoryData(repository_data=facet_item[0]),
+                              facet_item[1])
                 facets['repository_data'][i] = repository
 
         filter_display = {}
@@ -1072,59 +1291,89 @@ def institutionView(request, institution_id, subnav=False, institution_type='rep
             if filter_type == 'collection_url':
                 filter_display['collection_url'] = []
                 for filter_item in queryParams['filters'][filter_type]:
-                    collection_api_url = re.match(r'^https://registry\.cdlib\.org/api/v1/collection/(?P<url>\d*)/?', filter_item)
+                    collection_api_url = re.match(
+                        r'^https://registry\.cdlib\.org/api/v1/collection/(?P<url>\d*)/?',
+                        filter_item)
                     if collection_api_url is not None:
-                        collection = getCollectionData(collection_id=collection_api_url.group('url'))
+                        collection = getCollectionData(
+                            collection_id=collection_api_url.group('url'))
                         collection.pop('local_id', None)
                         filter_display['collection_url'].append(collection)
             elif filter_type == 'repository_url':
                 filter_display['repository_url'] = []
                 for filter_item in queryParams['filters'][filter_type]:
-                    repository_api_url = re.match(r'^https://registry\.cdlib\.org/api/v1/repository/(?P<url>\d*)/', filter_item)
+                    repository_api_url = re.match(
+                        r'^https://registry\.cdlib\.org/api/v1/repository/(?P<url>\d*)/',
+                        filter_item)
                     if repository_api_url is not None:
-                        repository = getRepositoryData(repository_id=repository_api_url.group('url'))
+                        repository = getRepositoryData(
+                            repository_id=repository_api_url.group('url'))
                         repository.pop('local_id', None)
                         filter_display['repository_url'].append(repository)
             else:
-                filter_display[filter_type] = copy.copy(queryParams['filters'][filter_type])
+                filter_display[filter_type] = copy.copy(
+                    queryParams['filters'][filter_type])
 
         context = {
-            'q': queryParams['q'],
-            'rq': queryParams['rq'],
-            'filters': filter_display,
-            'rows': queryParams['rows'],
-            'start': queryParams['start'],
-            'sort': queryParams['sort'],
-            'search_results': solr_search.results,
-            'facets': facets,
-            'numFound': solr_search.numFound,
-            'pages': int(math.ceil(float(solr_search.numFound)/int(queryParams['rows']))),
-            'view_format': queryParams['view_format'],
-            'institution': institution_details,
-            'contact_information': contact_information,
+            'q':
+            queryParams['q'],
+            'rq':
+            queryParams['rq'],
+            'filters':
+            filter_display,
+            'rows':
+            queryParams['rows'],
+            'start':
+            queryParams['start'],
+            'sort':
+            queryParams['sort'],
+            'search_results':
+            solr_search.results,
+            'facets':
+            facets,
+            'numFound':
+            solr_search.numFound,
+            'pages':
+            int(
+                math.ceil(
+                    float(solr_search.numFound) / int(queryParams['rows']))),
+            'view_format':
+            queryParams['view_format'],
+            'institution':
+            institution_details,
+            'contact_information':
+            contact_information,
         }
 
         if institution_type == 'campus':
             context['title'] = institution_details['name']
             context['FACET_FILTER_TYPES'] = FACET_FILTER_TYPES
             context['campus_slug'] = institution_details['slug']
-            context['form_action'] = reverse('calisphere:campusView', kwargs={'campus_slug': institution_details['slug'], 'subnav': 'items'})
+            context['form_action'] = reverse(
+                'calisphere:campusView',
+                kwargs={
+                    'campus_slug': institution_details['slug'],
+                    'subnav': 'items'
+                })
             for campus in CAMPUS_LIST:
                 if institution_id == campus['id'] and 'featuredImage' in campus:
                     context['featuredImage'] = campus['featuredImage']
 
         if institution_type == 'repository':
-            context['FACET_FILTER_TYPES'] = list(facet_filter_type for facet_filter_type in FACET_FILTER_TYPES if facet_filter_type['facet'] != 'repository_data')
+            context['FACET_FILTER_TYPES'] = list(
+                facet_filter_type for facet_filter_type in FACET_FILTER_TYPES
+                if facet_filter_type['facet'] != 'repository_data')
             context['repository_id'] = institution_id
             context['uc_institution'] = uc_institution
-            context['form_action'] = reverse('calisphere:repositoryView', kwargs={'repository_id': institution_id, 'subnav': 'items'})
+            context['form_action'] = reverse(
+                'calisphere:repositoryView',
+                kwargs={'repository_id': institution_id,
+                        'subnav': 'items'})
 
             # title for UC institutions needs to show parent campus
             if uc_institution:
                 context['title'] = '{0} / {1}'.format(
-                    uc_institution[0]['name'],
-                    institution_details['name']
-                )
+                    uc_institution[0]['name'], institution_details['name'])
             else:
                 context['title'] = institution_details['name']
 
@@ -1139,8 +1388,11 @@ def institutionView(request, institution_id, subnav=False, institution_type='rep
                 institution_data = institution_data + "::" + institution_details['campus'][0]['name']
             queryParams['filters']['repository_data'] = [institution_data]
 
-        context['related_collections'] = relatedCollections(request, queryParams)
-        context['num_related_collections'] = len(queryParams['filters']['collection_url']) if len(queryParams['filters']['collection_url']) > 0 else len(facets['collection_data'])
+        context['related_collections'] = relatedCollections(
+            request, queryParams)
+        context['num_related_collections'] = len(queryParams['filters'][
+            'collection_url']) if len(queryParams['filters']['collection_url']
+                                      ) > 0 else len(facets['collection_data'])
         context['rc_page'] = queryParams['rc_page']
 
         return render(request, 'calisphere/institutionViewItems.html', context)
@@ -1161,10 +1413,13 @@ def institutionView(request, institution_id, subnav=False, institution_type='rep
             facet='true',
             facet_mincount=1,
             facet_limit='-1',
-            facet_field=['sort_collection_data']
-        )
+            facet_field=['sort_collection_data'])
 
-        pages = int(math.ceil(float(len(collections_solr_search.facet_counts['facet_fields']['sort_collection_data']))/10))
+        pages = int(
+            math.ceil(
+                float(
+                    len(collections_solr_search.facet_counts['facet_fields'][
+                        'sort_collection_data'])) / 10))
         # doing the search again;
         # could we slice this from the results above?
         collections_solr_search = SOLR_select(
@@ -1174,30 +1429,28 @@ def institutionView(request, institution_id, subnav=False, institution_type='rep
             fq=institutions_fq,
             facet='true',
             facet_mincount=1,
-            facet_offset=(page-1)*10,
+            facet_offset=(page - 1) * 10,
             facet_limit='10',
             facet_field=['sort_collection_data'],
-            facet_sort='index',
-        )
+            facet_sort='index', )
 
         # solrpy gives us a dict == unsorted (!)
         # use the `facet_decade` mode of process_facets to do a lexical sort by value ....
         related_collections = list(
-            collection[0] for collection in process_facets(
-                collections_solr_search.facet_counts['facet_fields']['sort_collection_data'],
+            collection[0]
+            for collection in process_facets(
+                collections_solr_search.facet_counts['facet_fields'][
+                    'sort_collection_data'],
                 [],
-                'facet_decade',
-            )
-        )
+                'facet_decade', ))
         for i, related_collection in enumerate(related_collections):
             collection_parts = process_sort_collection_data(related_collection)
             collection_data = getCollectionData(
                 collection_data='{0}::{1}'.format(
                     collection_parts[2],
-                    collection_parts[1],
-                )
-            )
-            related_collections[i] = getCollectionMosaic(collection_data['url'])
+                    collection_parts[1], ))
+            related_collections[i] = getCollectionMosaic(
+                collection_data['url'])
 
         context = {
             'page': page,
@@ -1207,11 +1460,10 @@ def institutionView(request, institution_id, subnav=False, institution_type='rep
             'institution': institution_details,
         }
 
-        if page+1 <= pages:
-            context['next_page'] = page+1
-        if page-1 > 0:
-            context['prev_page'] = page-1
-
+        if page + 1 <= pages:
+            context['next_page'] = page + 1
+        if page - 1 > 0:
+            context['prev_page'] = page - 1
 
         if institution_type == 'campus':
             context['campus_slug'] = institution_details['slug']
@@ -1228,12 +1480,9 @@ def institutionView(request, institution_id, subnav=False, institution_type='rep
             # refactor, as this is copy/pasted in this commit
             if uc_institution:
                 context['title'] = '{0} / {1}'.format(
-                    uc_institution[0]['name'],
-                    institution_details['name']
-                )
+                    uc_institution[0]['name'], institution_details['name'])
             else:
                 context['title'] = institution_details['name']
-
 
             if uc_institution == False:
                 for unit in FEATURED_UNITS:
@@ -1243,7 +1492,9 @@ def institutionView(request, institution_id, subnav=False, institution_type='rep
             if not 'featuredImage' in context:
                 context['featuredImage'] = None
 
-        return render(request, 'calisphere/institutionViewCollections.html', context)
+        return render(request, 'calisphere/institutionViewCollections.html',
+                      context)
+
 
 def campusView(request, campus_slug, subnav=False):
     campus_id = ''
@@ -1262,7 +1513,9 @@ def campusView(request, campus_slug, subnav=False):
         campus_details = json_loads_url(campus_url + "?format=json")
 
         if 'ark' in campus_details and campus_details['ark'] != '':
-            contact_information = json_loads_url("http://dsc.cdlib.org/institution-json/" + campus_details['ark'])
+            contact_information = json_loads_url(
+                "http://dsc.cdlib.org/institution-json/" +
+                campus_details['ark'])
         else:
             contact_information = ''
 
@@ -1276,15 +1529,20 @@ def campusView(request, campus_slug, subnav=False):
             facet='true',
             facet_mincount=1,
             facet_limit='-1',
-            facet_field = ['repository_data']
-        )
+            facet_field=['repository_data'])
 
-        related_institutions = list(institution[0] for institution in process_facets(institutions_solr_search.facet_counts['facet_fields']['repository_data'], []))
+        related_institutions = list(
+            institution[0]
+            for institution in process_facets(
+                institutions_solr_search.facet_counts['facet_fields'][
+                    'repository_data'], []))
 
         for i, related_institution in enumerate(related_institutions):
-            related_institutions[i] = getRepositoryData(repository_data=related_institution)
-        related_institutions = sorted(related_institutions, key=lambda related_institution: related_institution['name'])
-
+            related_institutions[i] = getRepositoryData(
+                repository_data=related_institution)
+        related_institutions = sorted(
+            related_institutions,
+            key=lambda related_institution: related_institution['name'])
 
         return render(request, 'calisphere/institutionViewInstitutions.html', {
             'title': campus_name,
@@ -1298,12 +1556,15 @@ def campusView(request, campus_slug, subnav=False):
     else:
         return institutionView(request, campus_id, subnav, 'campus')
 
+
 def repositoryView(request, repository_id, subnav=False):
     return institutionView(request, repository_id, subnav, 'repository')
 
+
 def contactOwner(request):
     # print request.GET
-    return render(request, 'calisphere/thankyou.html');
+    return render(request, 'calisphere/thankyou.html')
+
 
 def posters(request):
     this_dir = os.path.dirname(os.path.realpath(__file__))
@@ -1311,9 +1572,9 @@ def posters(request):
     poster_data = json.loads(open(this_data).read())
     poster_data = sorted(poster_data.items())
 
-    return render(request, 'calisphere/posters.html', {
-        'poster_data': poster_data
-    })
+    return render(request, 'calisphere/posters.html',
+                  {'poster_data': poster_data})
+
 
 def sitemapSection(request, section):
     storage = _lazy_load(conf.STORAGE_CLASS)(location=conf.ROOT_DIR)
@@ -1323,6 +1584,7 @@ def sitemapSection(request, section):
     content = f.readlines()
     f.close()
     return HttpResponse(content, content_type='application/xml')
+
 
 def sitemapSectionZipped(request, section):
     storage = _lazy_load(conf.STORAGE_CLASS)(location=conf.ROOT_DIR)

--- a/calisphere/views.py
+++ b/calisphere/views.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import Http404, JsonResponse, HttpResponse
 from calisphere.collection_data import CollectionManager
-from .constants import CAMPUS_LIST, FACET_FILTER_TYPES, FEATURED_UNITS
+from .constants import CAMPUS_LIST, DEFAULT_FACET_FILTER_TYPES, FACET_FILTER_TYPES, FEATURED_UNITS
 from .cache_retry import SOLR_select, SOLR_raw, json_loads_url
 from static_sitemaps.util import _lazy_load
 from static_sitemaps import conf
@@ -1382,7 +1382,7 @@ def institutionView(request,
             else:
                 context['title'] = institution_details['name']
 
-            if uc_institution == False:
+            if uc_institution is False:
                 for unit in FEATURED_UNITS:
                     if unit['id'] == institution_id:
                         context['featuredImage'] = unit['featuredImage']
@@ -1489,12 +1489,12 @@ def institutionView(request,
             else:
                 context['title'] = institution_details['name']
 
-            if uc_institution == False:
+            if uc_institution is False:
                 for unit in FEATURED_UNITS:
                     if unit['id'] == institution_id:
                         context['featuredImage'] = unit['featuredImage']
 
-            if not 'featuredImage' in context:
+            if 'featuredImage' not in context:
                 context['featuredImage'] = None
 
         return render(request, 'calisphere/institutionViewCollections.html',

--- a/calisphere/views.py
+++ b/calisphere/views.py
@@ -1,12 +1,12 @@
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function
 from django.apps import apps
 from django.shortcuts import render, redirect
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import Http404, JsonResponse, HttpResponse
 from calisphere.collection_data import CollectionManager
-from constants import *
-from cache_retry import SOLR_select, SOLR_raw, json_loads_url
+from .constants import CAMPUS_LIST, FACET_FILTER_TYPES, FEATURED_UNITS
+from .cache_retry import SOLR_select, SOLR_raw, json_loads_url
 from static_sitemaps.util import _lazy_load
 from static_sitemaps import conf
 
@@ -75,7 +75,7 @@ def process_sort_collection_data(string):
     else:
         part1, remainder = string.split(':', 1)
         part2, part3 = remainder.rsplit(':https:')
-        return [part1, part2, u'https:{}'.format(part3)]
+        return [part1, part2, 'https:{}'.format(part3)]
 
 def getMoreCollectionData(collection_data):
     collection = getCollectionData(
@@ -97,7 +97,7 @@ def getCollectionData(collection_data=None, collection_id=None):
         collection['name'] = parts[1] if len(parts) >= 2 else ''
         collection_api_url = re.match(r'^https://registry\.cdlib\.org/api/v1/collection/(?P<url>\d*)/?', collection['url'])
         if collection_api_url is None:
-            print 'no collection api url:'
+            print('no collection api url:')
             collection['id'] = ''
         else:
             collection['id'] = collection_api_url.group('url')
@@ -182,7 +182,7 @@ def getRepositoryData(repository_data=None, repository_id=None, repository_url=N
             repository['url']
         )
         if repository_api_url is None:
-            print 'no repository api url'
+            print('no repository api url')
             repository['id'] = ''
         else:
             repository['id'] = repository_api_url.group('url')
@@ -201,7 +201,7 @@ def getRepositoryData(repository_data=None, repository_id=None, repository_url=N
     # details needed for stats
     repository['ga_code'] = repository_details.get('google_analytics_tracking_code', None)
     parent = repository_details['campus']
-    pslug = u''
+    pslug = ''
     if len(parent):
         pslug = '{0}-'.format(parent[0].get('slug', None))
     repository['slug'] = pslug + repository_details.get('slug', None)
@@ -349,7 +349,7 @@ def getHostedContentFile(structmap):
             structmap['id']
         )
         if structmap_url.startswith('//'):
-            structmap_url = u''.join(['http:', structmap_url])
+            structmap_url = ''.join(['http:', structmap_url])
         size = json_loads_url(structmap_url)['sizes'][-1]
         if size['height'] > size['width']:
             access_size = {'width': ((size['width'] * 1024) / size['height']), 'height': 1024}
@@ -494,7 +494,7 @@ def itemView(request, item_id=''):
     if item_solr_search.results[0].get('reference_image_md5', False):
         meta_image = urlparse.urljoin(
             settings.UCLDC_FRONT,
-            u'/crop/999x999/{0}'.format(item_solr_search.results[0]['reference_image_md5']),
+            '/crop/999x999/{0}'.format(item_solr_search.results[0]['reference_image_md5']),
         )
 
     fromItemPage = request.META.get("HTTP_X_FROM_ITEM_PAGE")
@@ -541,7 +541,7 @@ def search(request):
         )
 
         # TODO: create a no results found page
-        if len(solr_search.results) == 0: print 'no results found'
+        if len(solr_search.results) == 0: print('no results found')
 
         # get facet counts
         facets = facetQuery(facet_fields, queryParams, solr_search)
@@ -722,7 +722,7 @@ def relatedCollections(request, queryParams={}):
             if queryParams['campus_slug'] == campus['slug']:
                 campus_id = campus['id']
         if campus_id == '':
-            print "Campus registry ID not found"
+            print('Campus registry ID not found')
 
         fq.append('campus_url: "https://registry.cdlib.org/api/v1/campus/' + campus_id + '/"')
 
@@ -1121,7 +1121,7 @@ def institutionView(request, institution_id, subnav=False, institution_type='rep
 
             # title for UC institutions needs to show parent campus
             if uc_institution:
-                context['title'] = u'{0} / {1}'.format(
+                context['title'] = '{0} / {1}'.format(
                     uc_institution[0]['name'],
                     institution_details['name']
                 )
@@ -1192,7 +1192,7 @@ def institutionView(request, institution_id, subnav=False, institution_type='rep
         for i, related_collection in enumerate(related_collections):
             collection_parts = process_sort_collection_data(related_collection)
             collection_data = getCollectionData(
-                collection_data=u'{0}::{1}'.format(
+                collection_data='{0}::{1}'.format(
                     collection_parts[2],
                     collection_parts[1],
                 )
@@ -1227,7 +1227,7 @@ def institutionView(request, institution_id, subnav=False, institution_type='rep
             # title for UC institutions needs to show parent campus
             # refactor, as this is copy/pasted in this commit
             if uc_institution:
-                context['title'] = u'{0} / {1}'.format(
+                context['title'] = '{0} / {1}'.format(
                     uc_institution[0]['name'],
                     institution_details['name']
                 )
@@ -1255,7 +1255,7 @@ def campusView(request, campus_slug, subnav=False):
             if 'featuredImage' in campus:
                 featured_image = campus['featuredImage']
     if campus_id == '':
-        print "Campus registry ID not found"
+        print('Campus registry ID not found')
 
     if subnav == 'institutions':
         campus_url = 'https://registry.cdlib.org/api/v1/campus/' + campus_id + '/'
@@ -1312,7 +1312,7 @@ def posters(request):
     poster_data = sorted(poster_data.items())
 
     return render(request, 'calisphere/posters.html', {
-        'poster_data': poster_data 
+        'poster_data': poster_data
     })
 
 def sitemapSection(request, section):

--- a/exhibits/admin.py
+++ b/exhibits/admin.py
@@ -1,12 +1,14 @@
 from __future__ import unicode_literals
+from __future__ import absolute_import
 
 from django.contrib import admin
 from django.utils.safestring import mark_safe
 from django import forms
+from django.db import models
 
 # Register your models here.
 
-from models import *
+from .models import *
 
 class ExhibitItemInline(admin.TabularInline):
     model = ExhibitItem

--- a/exhibits/models.py
+++ b/exhibits/models.py
@@ -16,9 +16,6 @@ from past import autotranslate
 autotranslate(['md5s3stash'])
 from md5s3stash import md5s3stash
 
-# only if you need to support python 2:
-from django.utils.encoding import python_2_unicode_compatible
-
 RENDERING_OPTIONS = (
     ('H', 'HTML'),
     ('T', 'Plain Text'),

--- a/exhibits/models.py
+++ b/exhibits/models.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+from builtins import object
 import os.path
 
 from django.contrib.auth.models import User
@@ -11,9 +12,11 @@ from django.utils.encoding import python_2_unicode_compatible
 from calisphere.views import getCollectionData, getRepositoryData
 from django.conf import settings
 from exhibits.custom_fields import HeroField
+from past import autotranslate
+autotranslate(['md5s3stash'])
 from md5s3stash import md5s3stash
 
-# only if you need to support python 2: 
+# only if you need to support python 2:
 from django.utils.encoding import python_2_unicode_compatible
 
 RENDERING_OPTIONS = (
@@ -60,7 +63,7 @@ class Exhibit(models.Model):
 
     meta_description = models.CharField(max_length=255, blank=True)
     meta_keywords = models.CharField(max_length=255, blank=True)
-    
+
     objects = PublishedExhibitManager()
 
     def __str__(self):
@@ -114,9 +117,9 @@ class Exhibit(models.Model):
                 return settings.THUMBNAIL_URL + "crop/298x121/" + self.hero.name
             else:
                 return None
-    
+
     def social_media_card(self):
-        if self.item_id: 
+        if self.item_id:
             item_id_search_term = 'id:"{0}"'.format(self.item_id)
             item_solr_search = SOLR_select(q=item_id_search_term)
             if len(item_solr_search.results) > 0 and 'reference_image_md5' in item_solr_search.results[0]:
@@ -133,7 +136,7 @@ class Exhibit(models.Model):
         super(Exhibit, self).save(*args, **kwargs)
         for s3field in self.push_to_s3:
             name = getattr(self, s3field).name
-            if name: 
+            if name:
                 url = settings.MEDIA_ROOT + "/" + name
                 if os.path.isfile(url):
                     field_instance = getattr(self, s3field)
@@ -167,19 +170,19 @@ class HistoricalEssay(models.Model):
     blockquote = models.CharField(max_length=200, blank=True)
     essay = models.TextField(blank=True)
     render_as = models.CharField(max_length=1, choices=RENDERING_OPTIONS, default='H')
-    
+
     byline = models.TextField(blank=True)
     byline_render_as = models.CharField(max_length=1, choices=RENDERING_OPTIONS, default='H', verbose_name='Render byline as')
     go_further = models.TextField(blank=True)
     go_further_render_as = models.CharField(max_length=1, choices=RENDERING_OPTIONS, default='H', verbose_name='Render as')
-    
+
     publish = models.BooleanField(verbose_name='Ready for publication?', default=False)
     color = models.CharField(max_length=20, blank=True, help_text="Please provide color in <code>#xxx</code>, <code>#xxxxxx</code>, <code>rgb(xxx,xxx,xxx)</code>, or <code>rgba(xxx,xxx,xxx,x.x)</code> formats.")
     meta_description = models.CharField(max_length=255, blank=True)
     meta_keywords = models.CharField(max_length=255, blank=True)
 
     objects = PublishedHistoricalEssayManager()
-        
+
     def published_exhibits(self):
         if settings.EXHIBIT_PREVIEW:
             return self.historicalessayexhibit_set
@@ -226,7 +229,7 @@ class HistoricalEssay(models.Model):
                 return None
 
     def social_media_card(self):
-        if self.item_id: 
+        if self.item_id:
             item_id_search_term = 'id:"{0}"'.format(self.item_id)
             item_solr_search = SOLR_select(q=item_id_search_term)
             if len(item_solr_search.results) > 0 and 'reference_image_md5' in item_solr_search.results[0]:
@@ -265,7 +268,7 @@ class LessonPlan(models.Model):
     grade_level = models.CharField(max_length=200, blank=True)
     byline = models.TextField(blank=True)
     byline_render_as = models.CharField(max_length=1, choices=RENDERING_OPTIONS, default='H')
-    
+
     publish = models.BooleanField(verbose_name='Ready for publication?', default=False)
     meta_description = models.CharField(max_length=255, blank=True)
     meta_keywords = models.CharField(max_length=255, blank=True)
@@ -274,7 +277,7 @@ class LessonPlan(models.Model):
 
     def __str__(self):
         return self.title
-    
+
     def published_themes(self):
         if settings.EXHIBIT_PREVIEW:
             return self.lessonplantheme_set
@@ -338,7 +341,7 @@ class PublishedThemeManager(models.Manager):
             return super(PublishedThemeManager, self).get_queryset().filter(publish=True)
 
 @python_2_unicode_compatible
-class Theme(models.Model): 
+class Theme(models.Model):
     title = models.CharField(max_length=200)
     sort_title = models.CharField(blank=True, max_length=200, verbose_name='Sortable Title')
     slug = models.SlugField(max_length=255, unique=True)
@@ -347,7 +350,7 @@ class Theme(models.Model):
     byline_render_as = models.CharField(max_length=1, choices=RENDERING_OPTIONS, default='H')
     essay = models.TextField(blank=True, verbose_name='Theme overview')
     render_as = models.CharField(max_length=1, choices=RENDERING_OPTIONS, default='H')
-    
+
     hero = models.ImageField(blank=True, verbose_name='Hero Image', upload_to='uploads/')
     lockup_derivative = models.ImageField(blank=True, null=True, verbose_name='Lockup Image', upload_to='uploads/')
     alternate_lockup_derivative = models.ImageField(blank=True, null=True, verbose_name='Alternate Lockup Image', upload_to='uploads/')
@@ -424,7 +427,7 @@ class Theme(models.Model):
                     self._meta.get_field(s3field).upload_to = upload_to
 
     def social_media_card(self):
-        if self.item_id: 
+        if self.item_id:
             item_id_search_term = 'id:"{0}"'.format(self.item_id)
             item_solr_search = SOLR_select(q=item_id_search_term)
             if len(item_solr_search.results) > 0 and 'reference_image_md5' in item_solr_search.results[0]:
@@ -488,7 +491,7 @@ class ExhibitItem(models.Model):
     def imgUrl(self):
         if self.custom_crop:
             return settings.THUMBNAIL_URL + "crop/210x210/" + self.custom_crop.name
-        else: 
+        else:
             item_id_search_term = 'id:"{0}"'.format(self.item_id)
             item_solr_search = SOLR_select(q=item_id_search_term)
             if len(item_solr_search.results) > 0 and 'reference_image_md5' in item_solr_search.results[0]:
@@ -524,7 +527,7 @@ class NotesItem(models.Model):
     def __str__(self):
         return self.title
 
-    class Meta:
+    class Meta(object):
         ordering = ['order']
 
 @python_2_unicode_compatible
@@ -540,7 +543,7 @@ class BrowseTermGroup(models.Model):
     def __str__(self):
         return self.group_title
 
-    class Meta:
+    class Meta(object):
         ordering = ['order']
 
 @python_2_unicode_compatible
@@ -553,7 +556,7 @@ class BrowseTerm(models.Model):
     def __str__(self):
         return self.link_text
 
-    class Meta:
+    class Meta(object):
         ordering = ['order']
 
 
@@ -595,7 +598,7 @@ class LessonPlanTheme(models.Model):
     lessonPlan = models.ForeignKey(LessonPlan, on_delete=models.CASCADE)
     theme = models.ForeignKey(Theme, on_delete=models.CASCADE)
     order = PositionField(collection='theme')
-    
+
     class Meta(object):
         unique_together = ('lessonPlan', 'theme')
         verbose_name = 'Lesson Plan'
@@ -605,7 +608,7 @@ class HistoricalEssayTheme(models.Model):
     historicalEssay = models.ForeignKey(HistoricalEssay, on_delete=models.CASCADE)
     theme = models.ForeignKey(Theme, on_delete=models.CASCADE)
     order = PositionField(collection='theme')
-    
+
     class Meta(object):
         unique_together = ('historicalEssay', 'theme')
         verbose_name = 'Historical Essay'

--- a/exhibits/scrape_topics.py
+++ b/exhibits/scrape_topics.py
@@ -1,3 +1,5 @@
+from builtins import input
+from builtins import str
 from bs4 import BeautifulSoup
 from exhibits.models import Exhibit, NotesItem, ExhibitItem
 from django.utils.text import slugify
@@ -10,7 +12,7 @@ def getEssay(soup, topic):
     essay_text = ''
 
     while user_input != 'stop':
-        user_input = raw_input(topic_content)
+        user_input = eval(input(topic_content))
         if user_input == 's':
             topic_content = topic_content.find_next('h2')
         elif user_input == 'n':
@@ -24,10 +26,10 @@ def getEssay(soup, topic):
                 topic.content.name = 'h6'
             elif topic_content.name == 'h6':
                 topic_content.name = 'b'
-            essay_text = essay_text + unicode(topic_content)
+            essay_text = essay_text + str(topic_content)
             topic_content = topic_content.find_next()
         else: 
-            user_input = raw_input('whoops, try again')
+            user_input = eval(input('whoops, try again'))
 
     e = Exhibit(title=soup.h1.string, slug=slugify(soup.h1.string), essay=essay_text, scraped_from=topic)
     e.save()
@@ -40,7 +42,7 @@ def getSidebar(soup, e):
        sidebar_content = ""
        for c in s.contents:
          if c.name != 'h1':
-           sidebar_content = sidebar_content + unicode(c.string)
+           sidebar_content = sidebar_content + str(c.string)
        note = NotesItem(title=s.h1.text, essay=sidebar_content, exhibit_id=e.id)
        note.save()
 

--- a/exhibits/views.py
+++ b/exhibits/views.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+from builtins import range
 from django.shortcuts import get_object_or_404, render, redirect
 from django.http import HttpResponse
 from django.core.exceptions import ObjectDoesNotExist

--- a/public_interface/context_processors.py
+++ b/public_interface/context_processors.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals, print_function
 import urlparse
 
+
 def settings(request):
     """
     Put selected settings variables into the default template context
@@ -8,10 +9,7 @@ def settings(request):
     from django.conf import settings
     permalink = urlparse.urljoin(settings.UCLDC_FRONT, request.path)
     if request.META['QUERY_STRING']:
-        permalink = '?'.join([
-            permalink,
-            request.META['QUERY_STRING']
-        ])
+        permalink = '?'.join([permalink, request.META['QUERY_STRING']])
     return {
         'thumbnailUrl': settings.THUMBNAIL_URL,
         'devMode': settings.UCLDC_DEVEL,
@@ -37,4 +35,3 @@ def settings(request):
         'referral': None,
         'exhibitMedia': settings.MEDIA_URL
     }
-

--- a/public_interface/context_processors.py
+++ b/public_interface/context_processors.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals, print_function
 import urlparse
 
 def settings(request):
@@ -7,7 +8,7 @@ def settings(request):
     from django.conf import settings
     permalink = urlparse.urljoin(settings.UCLDC_FRONT, request.path)
     if request.META['QUERY_STRING']:
-        permalink = u'?'.join([
+        permalink = '?'.join([
             permalink,
             request.META['QUERY_STRING']
         ])

--- a/public_interface/context_processors.py
+++ b/public_interface/context_processors.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals, print_function
-import urlparse
+from future import standard_library
+standard_library.install_aliases()
+import urllib.parse
 
 
 def settings(request):
@@ -7,7 +9,7 @@ def settings(request):
     Put selected settings variables into the default template context
     """
     from django.conf import settings
-    permalink = urlparse.urljoin(settings.UCLDC_FRONT, request.path)
+    permalink = urllib.parse.urljoin(settings.UCLDC_FRONT, request.path)
     if request.META['QUERY_STRING']:
         permalink = '?'.join([permalink, request.META['QUERY_STRING']])
     return {

--- a/public_interface/settings.py
+++ b/public_interface/settings.py
@@ -10,23 +10,22 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.6/ref/settings/
 """
 
-from django.utils.crypto import get_random_string # http://stackoverflow.com/a/16630719/1763984
+from django.utils.crypto import get_random_string  # http://stackoverflow.com/a/16630719/1763984
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
-THUMBNAIL_URL = os.getenv('UCLDC_THUMBNAIL_URL', 'http://localhost:8888/')  # `python thumbnail.py`
+THUMBNAIL_URL = os.getenv('UCLDC_THUMBNAIL_URL',
+                          'http://localhost:8888/')  # `python thumbnail.py`
 S3_STASH = os.getenv('UCLDC_S3_STASH', '')
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.getenv('DJANGO_SECRET_KEY',
-                       get_random_string(50,
-                                         'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'
-                       )
-             )
-
+SECRET_KEY = os.getenv(
+    'DJANGO_SECRET_KEY',
+    get_random_string(50,
+                      'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'))
 
 SOLR_URL = os.getenv('UCLDC_SOLR_URL', 'http://localhost:8983/solr')
 SOLR_API_KEY = os.getenv('UCLDC_SOLR_API_KEY', '')
@@ -34,9 +33,10 @@ UCLDC_IMAGES = os.getenv('UCLDC_IMAGES', '')
 UCLDC_MEDIA = os.getenv('UCLDC_MEDIA', '')
 UCLDC_IIIF = os.getenv('UCLDC_IIIF', '')
 UCLDC_NUXEO_THUMBS = os.getenv('UCLDC_NUXEO_THUMBS', '')
-UCLDC_REGISTRY_URL = os.getenv('UCLDC_REGISTRY_URL', 'https://registry.cdlib.org/')
+UCLDC_REGISTRY_URL = os.getenv('UCLDC_REGISTRY_URL',
+                               'https://registry.cdlib.org/')
 
-UCLDC_FRONT = os.getenv('UCLDC_FRONT','')
+UCLDC_FRONT = os.getenv('UCLDC_FRONT', '')
 UCLDC_REDIS_URL = os.getenv('UCLDC_REDIS_URL', False)
 
 EMAIL_BACKEND = os.getenv('EMAIL_BACKEND',
@@ -51,9 +51,7 @@ CSRF_COOKIE_SECURE = bool(os.getenv('CSRF_COOKIE_SECURE', ''))
 
 DEFAULT_FROM_EMAIL = os.getenv('DEFAULT_FROM_EMAIL', 'project@example.edu')
 
-
-
-ADMINS = (('', DEFAULT_FROM_EMAIL),)
+ADMINS = (('', DEFAULT_FROM_EMAIL), )
 MANAGERS = ADMINS
 
 GA_SITE_CODE = os.getenv('UCLDC_GA_SITE_CODE', False)
@@ -78,9 +76,11 @@ ALLOWED_HOSTS = [
     '127.0.0.1',
 ]
 
-EC2_PRIVATE_IP  =   None
+EC2_PRIVATE_IP = None
 try:
-    EC2_PRIVATE_IP  =   requests.get('http://169.254.169.254/latest/meta-data/local-ipv4', timeout = 0.01).text
+    EC2_PRIVATE_IP = requests.get(
+        'http://169.254.169.254/latest/meta-data/local-ipv4',
+        timeout=0.01).text
 except requests.exceptions.RequestException:
     pass
 
@@ -91,24 +91,13 @@ SITE_ID = 1
 
 # Application definition
 
-INSTALLED_APPS = (
-    'exhibits.apps.ExhibitsConfig',
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'django.contrib.sites',
-    'django.contrib.humanize',
-    'django.contrib.sitemaps',
-    'easy_pjax',
-    'calisphere',
-    'static_sitemaps',
-    'health_check',
-    'health_check.cache',
-    'health_check.storage',
-)
+INSTALLED_APPS = ('exhibits.apps.ExhibitsConfig', 'django.contrib.admin',
+                  'django.contrib.auth', 'django.contrib.contenttypes',
+                  'django.contrib.sessions', 'django.contrib.messages',
+                  'django.contrib.staticfiles', 'django.contrib.sites',
+                  'django.contrib.humanize', 'django.contrib.sitemaps',
+                  'easy_pjax', 'calisphere', 'static_sitemaps', 'health_check',
+                  'health_check.cache', 'health_check.storage', )
 
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',  # are we using sessions?
@@ -120,8 +109,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
-)
+    'django.middleware.clickjacking.XFrameOptionsMiddleware', )
 
 ROOT_URLCONF = 'public_interface.urls'
 
@@ -129,31 +117,28 @@ WSGI_APPLICATION = 'public_interface.wsgi.application'
 
 APPEND_SLASH = True
 
-TEMPLATES = [
-    {
-        "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
-        "APP_DIRS": True,
-        "OPTIONS": {
-            "builtins": [
-                "easy_pjax.templatetags.pjax_tags"
-            ],
-            "context_processors": [
-                "django.template.context_processors.request",
-                "django.contrib.auth.context_processors.auth",
-                "django.contrib.messages.context_processors.messages",
-                'public_interface.context_processors.settings',
-            ],
-            "debug": UCLDC_DEVEL,
-            'loaders': [
-                ('django.template.loaders.cached.Loader', [
-                    'django.template.loaders.filesystem.Loader',
-                    'django.template.loaders.app_directories.Loader', ]
-                ),
-            ],
-        }
+TEMPLATES = [{
+    "BACKEND": "django.template.backends.django.DjangoTemplates",
+    "DIRS": [],
+    "APP_DIRS": True,
+    "OPTIONS": {
+        "builtins": ["easy_pjax.templatetags.pjax_tags"],
+        "context_processors": [
+            "django.template.context_processors.request",
+            "django.contrib.auth.context_processors.auth",
+            "django.contrib.messages.context_processors.messages",
+            'public_interface.context_processors.settings',
+        ],
+        "debug":
+        UCLDC_DEVEL,
+        'loaders': [
+            ('django.template.loaders.cached.Loader', [
+                'django.template.loaders.filesystem.Loader',
+                'django.template.loaders.app_directories.Loader',
+            ]),
+        ],
     }
-]
+}]
 
 if UCLDC_DEVEL or DEBUG or 1 == 1:
     # turn off template cache if we are debugging
@@ -161,13 +146,13 @@ if UCLDC_DEVEL or DEBUG or 1 == 1:
     TEMPLATES[0]['OPTIONS'].pop('loaders', None)
     TEMPLATES[0]['OPTIONS']['debug'] = True
 
-
 # Database
 # https://docs.djangoproject.com/en/1.6/ref/settings/#databases
 
-DATABASES = { }
+DATABASES = {}
 
-if os.environ.get('RDS_DB_NAME') and not os.environ.get('UCLDC_EXHIBITIONS_DATA'):
+if os.environ.get(
+        'RDS_DB_NAME') and not os.environ.get('UCLDC_EXHIBITIONS_DATA'):
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql_psycopg2',
@@ -190,7 +175,7 @@ else:
 # Cache / Redis
 #
 
-DJANGO_CACHE_TIMEOUT = os.getenv('DJANGO_CACHE_TIMEOUT', 60*15) # seconds
+DJANGO_CACHE_TIMEOUT = os.getenv('DJANGO_CACHE_TIMEOUT', 60 * 15)  # seconds
 
 CACHE_MIDDLEWARE_ALIAS = 'default'
 CACHE_MIDDLEWARE_SECONDS = DJANGO_CACHE_TIMEOUT
@@ -215,19 +200,22 @@ if UCLDC_REDIS_URL:
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+        'NAME':
+        'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        'NAME':
+        'django.contrib.auth.password_validation.MinimumLengthValidator',
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+        'NAME':
+        'django.contrib.auth.password_validation.CommonPasswordValidator',
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+        'NAME':
+        'django.contrib.auth.password_validation.NumericPasswordValidator',
     },
 ]
-
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.6/topics/i18n/
@@ -253,15 +241,14 @@ MEDIA_URL = '/media/'
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.6/howto/static-files/
 
-STATIC_URL = os.getenv('UCLDC_STATIC_URL', 'http://localhost:9000/')  # `grunt serve`
+STATIC_URL = os.getenv('UCLDC_STATIC_URL',
+                       'http://localhost:9000/')  # `grunt serve`
 
 STATIC_ROOT = os.path.join(BASE_DIR, "static_root")
 
 STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
 
-STATICFILES_DIRS = (
-    os.path.join(BASE_DIR, "dist"),
-)
+STATICFILES_DIRS = (os.path.join(BASE_DIR, "dist"), )
 
 LOGGING = {
     'version': 1,

--- a/public_interface/settings.py
+++ b/public_interface/settings.py
@@ -56,7 +56,7 @@ EMAIL_BACKEND = getenv('EMAIL_BACKEND',
 EMAIL_HOST = getenv('EMAIL_HOST', '')
 EMAIL_HOST_PASSWORD = getenv('EMAIL_HOST_PASSWORD', '')
 EMAIL_HOST_USER = getenv('EMAIL_HOST_USER', '')
-EMAIL_PORT = getenv('EMAIL_PORT', '')
+EMAIL_PORT = int(getenv('EMAIL_PORT', ''))
 EMAIL_USE_TLS = bool(getenv('EMAIL_USE_TLS', ''))
 CSRF_COOKIE_SECURE = bool(getenv('CSRF_COOKIE_SECURE', ''))
 

--- a/public_interface/settings.py
+++ b/public_interface/settings.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function
 import requests
 """
 Django settings for public_interface project.

--- a/public_interface/settings.py
+++ b/public_interface/settings.py
@@ -12,50 +12,61 @@ https://docs.djangoproject.com/en/1.6/ref/settings/
 
 from django.utils.crypto import get_random_string  # http://stackoverflow.com/a/16630719/1763984
 
-# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
+import sys
 
+
+def getenv(variable, default):
+    ''' getenv wrapper that decodes the same as python 3 in python 2
+    '''
+    try:  # decode for python2
+        return os.getenv(variable, default).decode(sys.getfilesystemencoding())
+    except AttributeError:
+        return os.getenv(variable, default)
+
+
+# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
-THUMBNAIL_URL = os.getenv('UCLDC_THUMBNAIL_URL',
+THUMBNAIL_URL = getenv('UCLDC_THUMBNAIL_URL',
                           'http://localhost:8888/')  # `python thumbnail.py`
-S3_STASH = os.getenv('UCLDC_S3_STASH', '')
+S3_STASH = getenv('UCLDC_S3_STASH', '')
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.getenv(
+SECRET_KEY = getenv(
     'DJANGO_SECRET_KEY',
     get_random_string(50,
                       'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'))
 
-SOLR_URL = os.getenv('UCLDC_SOLR_URL', 'http://localhost:8983/solr')
-SOLR_API_KEY = os.getenv('UCLDC_SOLR_API_KEY', '')
-UCLDC_IMAGES = os.getenv('UCLDC_IMAGES', '')
-UCLDC_MEDIA = os.getenv('UCLDC_MEDIA', '')
-UCLDC_IIIF = os.getenv('UCLDC_IIIF', '')
-UCLDC_NUXEO_THUMBS = os.getenv('UCLDC_NUXEO_THUMBS', '')
-UCLDC_REGISTRY_URL = os.getenv('UCLDC_REGISTRY_URL',
+SOLR_URL = getenv('UCLDC_SOLR_URL', 'http://localhost:8983/solr')
+SOLR_API_KEY = getenv('UCLDC_SOLR_API_KEY', '')
+UCLDC_IMAGES = getenv('UCLDC_IMAGES', '')
+UCLDC_MEDIA = getenv('UCLDC_MEDIA', '')
+UCLDC_IIIF = getenv('UCLDC_IIIF', '')
+UCLDC_NUXEO_THUMBS = getenv('UCLDC_NUXEO_THUMBS', '')
+UCLDC_REGISTRY_URL = getenv('UCLDC_REGISTRY_URL',
                                'https://registry.cdlib.org/')
 
-UCLDC_FRONT = os.getenv('UCLDC_FRONT', '')
-UCLDC_REDIS_URL = os.getenv('UCLDC_REDIS_URL', False)
+UCLDC_FRONT = getenv('UCLDC_FRONT', '')
+UCLDC_REDIS_URL = getenv('UCLDC_REDIS_URL', False)
 
-EMAIL_BACKEND = os.getenv('EMAIL_BACKEND',
+EMAIL_BACKEND = getenv('EMAIL_BACKEND',
                           'django.core.mail.backends.console.EmailBackend')
 
-EMAIL_HOST = os.getenv('EMAIL_HOST', '')
-EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD', '')
-EMAIL_HOST_USER = os.getenv('EMAIL_HOST_USER', '')
-EMAIL_PORT = os.getenv('EMAIL_PORT', '')
-EMAIL_USE_TLS = bool(os.getenv('EMAIL_USE_TLS', ''))
-CSRF_COOKIE_SECURE = bool(os.getenv('CSRF_COOKIE_SECURE', ''))
+EMAIL_HOST = getenv('EMAIL_HOST', '')
+EMAIL_HOST_PASSWORD = getenv('EMAIL_HOST_PASSWORD', '')
+EMAIL_HOST_USER = getenv('EMAIL_HOST_USER', '')
+EMAIL_PORT = getenv('EMAIL_PORT', '')
+EMAIL_USE_TLS = bool(getenv('EMAIL_USE_TLS', ''))
+CSRF_COOKIE_SECURE = bool(getenv('CSRF_COOKIE_SECURE', ''))
 
-DEFAULT_FROM_EMAIL = os.getenv('DEFAULT_FROM_EMAIL', 'project@example.edu')
+DEFAULT_FROM_EMAIL = getenv('DEFAULT_FROM_EMAIL', 'project@example.edu')
 
 ADMINS = (('', DEFAULT_FROM_EMAIL), )
 MANAGERS = ADMINS
 
-GA_SITE_CODE = os.getenv('UCLDC_GA_SITE_CODE', False)
-UCLDC_WALKME = os.getenv('UCLDC_WALKME', False)
+GA_SITE_CODE = getenv('UCLDC_GA_SITE_CODE', False)
+UCLDC_WALKME = getenv('UCLDC_WALKME', False)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = bool(os.environ.get('UCLDC_DEBUG'))  # <-- this is django's debug
@@ -175,7 +186,7 @@ else:
 # Cache / Redis
 #
 
-DJANGO_CACHE_TIMEOUT = os.getenv('DJANGO_CACHE_TIMEOUT', 60 * 15)  # seconds
+DJANGO_CACHE_TIMEOUT = getenv('DJANGO_CACHE_TIMEOUT', 60 * 15)  # seconds
 
 CACHE_MIDDLEWARE_ALIAS = 'default'
 CACHE_MIDDLEWARE_SECONDS = DJANGO_CACHE_TIMEOUT
@@ -241,7 +252,7 @@ MEDIA_URL = '/media/'
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.6/howto/static-files/
 
-STATIC_URL = os.getenv('UCLDC_STATIC_URL',
+STATIC_URL = getenv('UCLDC_STATIC_URL',
                        'http://localhost:9000/')  # `grunt serve`
 
 STATIC_ROOT = os.path.join(BASE_DIR, "static_root")
@@ -261,7 +272,7 @@ LOGGING = {
     'loggers': {
         'django': {
             'handlers': ['console'],
-            'level': os.getenv('DJANGO_LOG_LEVEL', 'DEBUG'),
+            'level': getenv('DJANGO_LOG_LEVEL', 'DEBUG'),
         },
     },
 }

--- a/public_interface/settings.py
+++ b/public_interface/settings.py
@@ -56,7 +56,10 @@ EMAIL_BACKEND = getenv('EMAIL_BACKEND',
 EMAIL_HOST = getenv('EMAIL_HOST', '')
 EMAIL_HOST_PASSWORD = getenv('EMAIL_HOST_PASSWORD', '')
 EMAIL_HOST_USER = getenv('EMAIL_HOST_USER', '')
-EMAIL_PORT = int(getenv('EMAIL_PORT', ''))
+try:
+    EMAIL_PORT = int(getenv('EMAIL_PORT', ''))
+except ValueError:
+    pass
 EMAIL_USE_TLS = bool(getenv('EMAIL_USE_TLS', ''))
 CSRF_COOKIE_SECURE = bool(getenv('CSRF_COOKIE_SECURE', ''))
 

--- a/public_interface/upload_handlers.py
+++ b/public_interface/upload_handlers.py
@@ -3,12 +3,14 @@ from md5s3stash import md5s3stash
 from public_interface import settings
 from collections import namedtuple
 
-class Md5s3stashUploadHandler(uploadhandler.FileUploadHandler): 
+
+class Md5s3stashUploadHandler(uploadhandler.FileUploadHandler):
     def receive_data_chunk(self, raw_data, start):
         return raw_data
-    
+
     def file_complete(self, file_size):
         url = "file:///" + settings.MEDIA_ROOT + "/uploads/" + self.file_name
         report = md5s3stash(url, "static-ucldc-cdlib-org/harvested_images")
-        S3UploadedFile = namedtuple('S3UploadedFile', 'name, size, content_type')
+        S3UploadedFile = namedtuple('S3UploadedFile',
+                                    'name, size, content_type')
         return S3UploadedFile(report.md5, file_size, self.content_type)

--- a/public_interface/urls.py
+++ b/public_interface/urls.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals, print_function
 from django.conf.urls import include, url
 from django.contrib import admin
 from django.http import HttpResponse
@@ -8,7 +9,7 @@ from django.conf.urls.static import static
 from calisphere.contact_form_view import CalisphereContactFormView
 from exhibits.views import calCultures
 
-from calisphere.sitemaps import *
+from calisphere.sitemaps import CollectionSitemap, InstitutionSitemap, ItemSitemap, StaticSitemap
 
 admin.autodiscover()
 

--- a/public_interface/wsgi.py
+++ b/public_interface/wsgi.py
@@ -14,7 +14,6 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.wsgi import get_wsgi_application
 from whitenoise.django import DjangoWhiteNoise
 
-
 application = get_wsgi_application()
 
 try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ simplejson==3.10.0
 six==1.10.0
 requests==2.13.0
 whitenoise==3.3.0
-wsgiref==0.1.2
 markdown==2.6.8
 # django-positions==0.5.4
 https://github.com/amywieliczka/django-positions/archive/multi-collection-delete-issue.zip#egg=django-positions

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ redis==2.10.5
 hiredis==0.2.0
 django-static-sitemaps==4.2.1
 django-health-check==2.3.0
+future==0.16.0


### PR DESCRIPTION
`futurize -w` the application to python3 that will run on python2

`yapf -i` files in `public_interface` and `calisphere` to enforce common style

fine tune python code to work on python2/3 (including a wrapper for `os.getenv` that decodes strings consistently)

`calisphere/tests.py` actually does something now

to run tests, need some rigamarole or whitenoise will complain
```
# nvm use v0.10
grunt
git checkout app  # workaround for strange gruntfile plugin bug
python manage.py collectstatic --noinput
```

after this set up, then `python manage.py test` should work