### PR TITLE
Fix item `format` metadata

### DIFF
--- a/calisphere/templates/calisphere/item-metadata.html
+++ b/calisphere/templates/calisphere/item-metadata.html
@@ -91,11 +91,7 @@
 
     {% if 'format' in item %}
 			<dt class="meta-block__type">Format</dt>
-			{% if item.harvest_type == 'hosted' %}
-				<dd class="meta-block__defin">{{ item.format }}</dd>
-                        {% else %}
-				<dd class="meta-block__defin">{% for format in item.format %}{{ format }} <br> {% endfor %}</dd>
-                        {% endif %}
+			<dd class="meta-block__defin">{% for format in item.format %}{{ format }} <br> {% endfor %}</dd>
 		{% endif %}
 
     {% if 'genre' in item %}

--- a/calisphere/templates/calisphere/item.html
+++ b/calisphere/templates/calisphere/item.html
@@ -16,7 +16,7 @@
 
 <h1 class="obj__heading">
   {% if item.harvest_type == 'hosted' %}
-    {% if item.multiFormat %}Multi-format{% elif item.format %}{{ item.format|title }}{% else %}{{ item.type.0|title }}{% endif %}{% if 'structMap' in item %} set{% else %}{% endif %}
+    {% if item.multiFormat %}Multi-format{% else %}{{ item.type.0|title }}{% endif %}{% if 'structMap' in item %} set{% else %}{% endif %}
   {% else %}
     {{ item.type.0|title }}
   {% endif %}

--- a/calisphere/views.py
+++ b/calisphere/views.py
@@ -460,8 +460,6 @@ def itemView(request, item_id=''):
                                            'https://s3.amazonaws.com/static')
             structmap_data = json_loads_url(structmap_url)
 
-            item['format'] = structmap_data.get('format', '')
-
             if 'structMap' in structmap_data:
                 # complex object
                 if 'order' in request.GET and 'structMap' in structmap_data:


### PR DESCRIPTION
Backing out change that overwrote item.format with 'format' from
media.json