### PR TITLE
Update mediaelement.js to prevent clipping in fullscreen

### DIFF
--- a/.ebextensions/01syncdb.config
+++ b/.ebextensions/01syncdb.config
@@ -19,9 +19,11 @@ container_commands:
 # http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/create_deploy_Python_django.html
 
 option_settings:
+  - namespace: aws:elasticbeanstalk:command
+    option_name: Timeout
+    value: 1800
   - namespace: aws:elasticbeanstalk:container:python
     option_name: WSGIPath
     value: public_interface/wsgi.py
 #  - option_name: DJANGO_SETTINGS_MODULE
 #    value: mysite.settings
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_script:
 install: "pip install -r requirements.txt"
 
 script:
-  - python manage.py test
   - ./node_modules/.bin/grunt test
   - ./node_modules/.bin/grunt
+  - python manage.py collectstatic --noinput
+  - python manage.py test

--- a/app/scripts/ItemView.js
+++ b/app/scripts/ItemView.js
@@ -221,6 +221,28 @@ var ItemView = Backbone.View.extend({
     });
   },
 
+  // add the media element player if necessary
+  initMediaPlayer: function() {
+    if($('#obj__mejs').length) {
+      if (this.mediaplayer) {
+        if (!this.mediaplayer.paused) {
+          this.mediaplayer.pause();
+        }
+        this.mediaplayer.remove();
+        delete this.mediaplayer;
+      }
+
+      $('.media-player').mediaelementplayer({
+        stretching: 'responsive',
+        success: (function(that) {
+          return function(mediaElement, originalNode, instance) {
+            that.mediaplayer = instance;
+          };
+        }(this))
+      });
+    }
+  },
+
   // PJAX EVENT HANDLERS
   // ---------------------
   
@@ -266,10 +288,7 @@ var ItemView = Backbone.View.extend({
         linkItem.parent().toggleClass('carousel__item');
       }
 
-      // add the media element player if necessary
-      if($('#obj__mejs').length) {
-        $('.mejs-player').mediaelementplayer();
-      }
+      that.initMediaPlayer();
     };
   },
 
@@ -292,6 +311,7 @@ var ItemView = Backbone.View.extend({
     // initializes the carousel and the related collections
     this.initCarousel();
     this.paginateRelatedCollections();
+    this.initMediaPlayer();
 
     // bind pjax handlers to `this`   
     // we need to save the bound handler to `this.bound_pjax_end` so we can later 

--- a/app/styles/_mediaelementplayer-custom-styles.scss
+++ b/app/styles/_mediaelementplayer-custom-styles.scss
@@ -1,67 +1,57 @@
 // ##### Custom Styles for MediaElement.js ##### //
 
-// ***** Sass placeholders extended into video wrapper div within _object-container.scss to make mejs responsive (see: https://css-tricks.com/rundown-of-handling-flexible-media ) ***** //
-
-%mejs-custom__video-container .mejs-container {
-  width: 100% !important;
-  height: auto !important;
-  padding-top: 75%; // adjusts aspect ratio of container box
-}
-
-%mejs-custom__video-container .mejs-overlay, %mejs-custom__video-container .mejs-poster {
-  width: 100% !important;
-  height: 100% !important;
-}
-
-%mejs-custom__video-container .mejs-mediaelement video {
-  position: absolute;
-  top: 0; left: 0; right: 0; bottom: 0;
-  width: 100% !important;
-  height: 100% !important;
-}
-
-// ***** Global reset to make mejs responsive ***** //
-
-.mejs-player {
-  width: 100% !important;
-}
-
-// ***** Set the button image paths ***** //
-
-.mejs-controls .mejs-button button {
-  background-image: url("../bower_components/mediaelement/build/controls.svg");
-}
-
-.mejs-overlay-button {
-  background-image: url("../bower_components/mediaelement/build/bigplay.svg")
-}
+//// ***** Sass placeholders extended into video wrapper div within _object-container.scss to make mejs responsive (see: https://css-tricks.com/rundown-of-handling-flexible-media ) ***** //
+//
+//%mejs__custom__video-container .mejs__container {
+//  width: 100% !important;
+//  height: auto !important;
+//  padding-top: 75%; // adjusts aspect ratio of container box
+//}
+//
+//%mejs__custom__video-container .mejs__overlay, %mejs__custom__video-container .mejs__poster {
+//  width: 100% !important;
+//  height: 100% !important;
+//}
+//
+//%mejs__custom__video-container .mejs__mediaelement video {
+//  position: absolute;
+//  top: 0; left: 0; right: 0; bottom: 0;
+//  width: 100% !important;
+//  height: 100% !important;
+//}
+//
+//// ***** Global reset to make mejs responsive ***** //
+//
+//.mejs__player {
+//  width: 100% !important;
+//}
 
 // ***** Reset the default mediaelementplayer.css skin colors ***** //
 
-.mejs-container .mejs-controls {
+.mejs__container .mejs__controls {
   background: $design-dark-gray-color;
 }
 
-.mejs-time-slider {
+.mejs__time-slider {
   border: 1px solid #fff;
   overflow: hidden;
 }
 
-.mejs-controls .mejs-time-rail .mejs-time-loaded {
+.mejs__controls .mejs__time-rail .mejs__time-loaded {
   background: $design-dark-gray-color;
 }
 
-.mejs-controls .mejs-time-rail .mejs-time-current {
+.mejs__controls .mejs__time-rail .mejs__time-current {
   background: $design-primary-color;
 }
 
-.mejs-controls .mejs-horizontal-volume-slider .mejs-horizontal-volume-total {
+.mejs__controls .mejs__horizontal-volume-slider .mejs__horizontal-volume-total {
   border: 1px solid #fff;
 }
 
-.mejs-controls .mejs-horizontal-volume-slider .mejs-horizontal-volume-current {
+.mejs__controls .mejs__horizontal-volume-slider .mejs__horizontal-volume-current {
   background: $design-primary-color;
-  border-top: 1px solid #fff;
-  border-bottom: 1px solid #fff;
-  border-left: 1px solid #fff;
+//  border-top: 1px solid #fff;
+//  border-bottom: 1px solid #fff;
+//  border-left: 1px solid #fff;
 }

--- a/app/styles/_object-container.scss
+++ b/app/styles/_object-container.scss
@@ -63,5 +63,5 @@
 
 .obj-container__video {
   @extend %obj-container__media-element;
-  @extend %mejs-custom__video-container; // This placeholder comes from _mediaelementplayer-custom-styles.scss
+//  @extend %mejs__custom__video-container; // This placeholder comes from _mediaelementplayer-custom-styles.scss
 }

--- a/app/styles/background.png
+++ b/app/styles/background.png
@@ -1,1 +1,0 @@
-../../bower_components/mediaelement/build/background.png

--- a/app/styles/bigplay.fw.png
+++ b/app/styles/bigplay.fw.png
@@ -1,1 +1,0 @@
-../../bower_components/mediaelement/build/bigplay.fw.png

--- a/app/styles/bigplay.png
+++ b/app/styles/bigplay.png
@@ -1,1 +1,0 @@
-../../bower_components/mediaelement/build/bigplay.png

--- a/app/styles/bigplay.svg
+++ b/app/styles/bigplay.svg
@@ -1,1 +1,0 @@
-../../bower_components/mediaelement/build/bigplay.svg

--- a/app/styles/controls-ted.png
+++ b/app/styles/controls-ted.png
@@ -1,1 +1,0 @@
-../../bower_components/mediaelement/build/controls-ted.png

--- a/app/styles/controls-wmp-bg.png
+++ b/app/styles/controls-wmp-bg.png
@@ -1,1 +1,0 @@
-../../bower_components/mediaelement/build/controls-wmp-bg.png

--- a/app/styles/controls-wmp.png
+++ b/app/styles/controls-wmp.png
@@ -1,1 +1,0 @@
-../../bower_components/mediaelement/build/controls-wmp.png

--- a/app/styles/controls.fw.png
+++ b/app/styles/controls.fw.png
@@ -1,1 +1,0 @@
-../../bower_components/mediaelement/build/controls.fw.png

--- a/app/styles/controls.png
+++ b/app/styles/controls.png
@@ -1,1 +1,0 @@
-../../bower_components/mediaelement/build/controls.png

--- a/app/styles/controls.svg
+++ b/app/styles/controls.svg
@@ -1,1 +1,0 @@
-../../bower_components/mediaelement/build/controls.svg

--- a/app/styles/loading.gif
+++ b/app/styles/loading.gif
@@ -1,1 +1,0 @@
-../../bower_components/mediaelement/build/loading.gif

--- a/app/styles/mejs-controls.svg
+++ b/app/styles/mejs-controls.svg
@@ -1,0 +1,1 @@
+../../bower_components/mediaelement/build/mejs-controls.svg

--- a/app/styles/silverlightmediaelement.xap
+++ b/app/styles/silverlightmediaelement.xap
@@ -1,1 +1,0 @@
-../../bower_components/mediaelement/build//silverlightmediaelement.xap

--- a/app/styles/skipback.png
+++ b/app/styles/skipback.png
@@ -1,1 +1,0 @@
-../../bower_components/mediaelement/build/skipback.png

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "slick.js": "=1.5.5",
     "fontawesome": "~4.7.0",
     "picturefill": "~2.2.0",
-    "mediaelement": "~2.16.4",
+    "mediaelement": "~4.1.2",
     "openseadragon": "~2.0.0",
     "infinite-scroll": "~2.1.0",
     "imagesloaded": "~3.1.8",

--- a/calisphere/templates/calisphere/objectViewer/hosted-simple-audio.html
+++ b/calisphere/templates/calisphere/objectViewer/hosted-simple-audio.html
@@ -1,11 +1,11 @@
 {% load staticfiles %}
 
   <div class="obj-container__audio">
-
-    <audio controls="controls" class="mejs-player" preload="none">
-      <source src="{{ item.contentFile.url }}" type="audio/mpeg">
-    </audio>
-
+    <div id="obj__mejs">
+      <audio controls="controls" class="media-player" preload="none">
+        <source src="{{ item.contentFile.url }}" type="audio/mpeg">
+      </audio>
+    </div>
     
     {% if item.harvest_type == 'hosted' and 'structMap' in item %}
       <div class="text__audio-component-title">{{ item.selectedComponent.label }}</div>

--- a/calisphere/templates/calisphere/objectViewer/hosted-simple-video.html
+++ b/calisphere/templates/calisphere/objectViewer/hosted-simple-video.html
@@ -2,7 +2,7 @@
 
   <div class="obj-container__video">
     <div id="obj__mejs">
-      <video controls="controls" class="mejs-player" preload="none" poster="{{ ucldcNuxeoThumbs }}{{ item.contentFile.id }}">
+      <video controls="controls" class="media-player" preload="none" poster="{{ ucldcNuxeoThumbs }}{{ item.contentFile.id }}">
         <source src="{{ item.contentFile.url }}" type="video/mp4">
       </video>
     </div>

--- a/calisphere/views.py
+++ b/calisphere/views.py
@@ -482,7 +482,7 @@ def itemView(request, item_id=''):
                 else:
                     item['selected'] = True
                     # if parent content file, get it
-                    if 'format' in structmap_data and structmap_data['format'] != 'file':
+                    if 'format' in structmap_data:
                         item['contentFile'] = getHostedContentFile(
                             structmap_data)
                     # otherwise get first component file


### PR DESCRIPTION
Updated mediaelement.js to most recent version (4.5.1)
mediaelement.js had changed all their class names, so our style overrides had to be updated as well.

We had previously been using auto instantiation by specifying a 'special' class name on the `<video>` and `<audio>` tags in the templates, and then instantiating the media player in the JavaScript only on `pjax:end` (and only for video objects). The new `initMediaPlayer()` method of `ItemView` handles instantiating the media player for both audio and video on both `ItemView`'s initialization and `ItemView`'s `pjax:end` event handler. Furthermore, it stores the media player instance in `this.mediaplayer` for removing it later. 