### PR TITLE
Custom facet fix

### DIFF
--- a/app/scripts/FacetFormView.js
+++ b/app/scripts/FacetFormView.js
@@ -31,7 +31,7 @@ var FacetFormView = Backbone.View.extend({
     'click .js-a-check__header'               : 'toggleFacetDropdown',
     'click .js-a-check__update'               : 'updateFacets',
     'click .js-rc-page'                       : 'paginateRelatedCollections',
-    'click .js-relatedCollection'             : 'goToCollectionPage'
+    'click .js-relatedCollection'             : 'clearQuery'
   },
 
   // **METHODS THAT CHANGE THE QUERY MANAGER**
@@ -299,7 +299,7 @@ var FacetFormView = Backbone.View.extend({
   // when a user navigates away from a search results page to a collection page
   // via related collections, they lose their search context.     
   // this is where it goes.
-  goToCollectionPage: function() {
+  clearQuery: function() {
     this.model.clear({silent: true});
   },
 

--- a/app/scripts/GlobalSearchFormView.js
+++ b/app/scripts/GlobalSearchFormView.js
@@ -36,7 +36,7 @@ var GlobalSearchFormView = Backbone.View.extend({
   // `events: 'click' '#js-global-header-logo'`   
   // Clear the query manager's current query state
   clearQueryManager: function() {
-    if (!_.isEmpty(this.model.attributes) || !_.isEmpty(sessionStorage)) {
+    if (!_.isEmpty(this.model.attributes)) {
       this.model.clear({silent: true});
     }
   },

--- a/app/scripts/ItemView.js
+++ b/app/scripts/ItemView.js
@@ -27,7 +27,7 @@ var ItemView = Backbone.View.extend({
     'beforeChange .carousel'         : 'loadSlides',
     'click .js-item-link'            : 'goToItemPage',
     'click .js-rc-page'              : 'paginateRelatedCollections',
-    'click .js-relatedCollection'    : 'goToCollectionPage'
+    'click .js-relatedCollection'    : 'clearQuery'
   },
 
   // `click` triggered on `#js-linkBack`    
@@ -148,7 +148,7 @@ var ItemView = Backbone.View.extend({
   },
 
   // `click` triggered on `.js-relatedCollection`
-  goToCollectionPage: function() {
+  clearQuery: function() {
     this.model.clear({silent: true});
   },
 

--- a/app/scripts/QueryManager.js
+++ b/app/scripts/QueryManager.js
@@ -46,10 +46,10 @@ var QueryManager = Backbone.Model.extend({
       // :visible differentiates between actual filters and implied filters,
       // such as collection_data on a collection page (stored in an <input hidden class=js-facet> elem)
       var filters;
-      if (formSelector === 'js-facet') {
+      if (formName === 'js-facet') {
         filters = $(formSelector + '.js-facet:visible').serializeArray();
       } else {
-        filters = $(formSelector + '.js-facet').serializeArray();
+        filters = $(formSelector + '.js-filter').serializeArray();
       }
       if (filters.length > 0) {
         for (var i=0; i<filters.length; i++) {
@@ -131,26 +131,7 @@ var QueryManager = Backbone.Model.extend({
 
   initialize: function() {
     var attributes;
-    if (sessionStorage.length > 0) {
-      attributes = {
-        q: sessionStorage.getItem('q'),
-        rq: JSON.parse(sessionStorage.getItem('rq')),
-        view_format: sessionStorage.getItem('view_format'),
-        sort: sessionStorage.getItem('sort'),
-        start: sessionStorage.getItem('start'),
-        type_ss: JSON.parse(sessionStorage.getItem('type_ss')),
-        facet_decade: JSON.parse(sessionStorage.getItem('facet_decade')),
-        repository_data: JSON.parse(sessionStorage.getItem('repository_data')),
-        collection_data: JSON.parse(sessionStorage.getItem('collection_data')),
-
-        campus_slug: sessionStorage.getItem('campus_slug'),
-        itemNumber: sessionStorage.getItem('itemNumber'),
-        itemId: sessionStorage.getItem('itemId'),
-        referral: sessionStorage.getItem('referral'),
-        referralName: sessionStorage.getItem('referralName')
-      };
-    } 
-    else if ($('[form=js-facet]').length) {
+    if ($('[form=js-facet]').length) {
       attributes = this.getQueryFromDOM('js-facet');
     }
     else if ($('[form=js-carouselForm]').length) {
@@ -163,22 +144,7 @@ var QueryManager = Backbone.Model.extend({
     });
     this.set(attributes);
   },
-  
-  setSessionStorage: function(value, key) {
-    if (_.isArray(value)) {
-      sessionStorage.setItem(key, JSON.stringify(value));
-    } else {
-      sessionStorage.setItem(key, value);
-    }
-  },
-  
-  unsetSessionStorage: function(value, key) {
-    if (key === undefined) {
-      key = value;
-    }
-    sessionStorage.removeItem(key);
-  },
-    
+
   set: function(key, value, options) {
     if (key === null) { return this; }
     
@@ -198,7 +164,7 @@ var QueryManager = Backbone.Model.extend({
         if (value !== undefined) {
           if ((that.defaultValues[key] !== undefined && that.defaultValues[key] === value) || (value.length === 0 && key !== 'q')) {
             delete list[key];
-            that.unsetSessionStorage(key);
+            // that.unsetSessionStorage(key);
             if (_.isEmpty(list)) {
               that.unset(key);
             } else {
@@ -210,16 +176,5 @@ var QueryManager = Backbone.Model.extend({
     }(this)));
         
     Backbone.Model.prototype.set.apply(this, [attrs, options]);
-    
-    if (!options.unset) {
-      _.each(attrs, this.setSessionStorage);
-    } else {
-      _.each(attrs, this.unsetSessionStorage);
-    }
-  },
-    
-  clear: function() {
-    Backbone.Model.prototype.clear.apply(this, arguments);
-    sessionStorage.clear();
-  }, 
+  }
 });

--- a/app/scripts/calisphere-home.js
+++ b/app/scripts/calisphere-home.js
@@ -1,18 +1,10 @@
 /*global _*/
 'use strict';
 
-if ($('.home').length) {
-  sessionStorage.clear();
-}
-
 $(document).ready(function() {
   if ($('.home').length) {
     _.each($('form'), function(el) {
       el.reset();
-    });
-
-    $(document).on('submit', '#js-searchForm, #js-homeForm, #js-footerSearch', function() {
-      sessionStorage.setItem('q', $(this).find('input').val());
     });
 
     $(document).on('click', '.js-global-header__bars-icon', function() {

--- a/calisphere/templates/calisphere/carouselContainer.html
+++ b/calisphere/templates/calisphere/carouselContainer.html
@@ -60,8 +60,10 @@
 
     {% for filter_type in filters %}
       {% for filter in filters|get_item:filter_type %}
-        {% if filter_type == 'collection_url' or filter_type == 'repository_url' %}
-          <input type="hidden" class="js-filter" name="{{ filter_type }}" value="{{ filter.id }}" form="js-carouselForm">
+        {% if filter_type == 'collection_url' %}
+          <input type="hidden" class="js-filter" name="{{ collection_data }}" value="{{ filter.id }}" form="js-carouselForm">
+        {% elif filter_type == 'repository_url' %}
+          <input type="hidden" class="js-filter" name="{{ repository_data }}" value="{{ filter.id }}" form="js-carouselForm">
         {% else %}
           <input type="hidden" class="js-filter" name="{{ filter_type }}" value="{{ filter|slugify }}" form="js-carouselForm">
         {% endif %}

--- a/calisphere/templates/calisphere/institutionViewItems.html
+++ b/calisphere/templates/calisphere/institutionViewItems.html
@@ -3,6 +3,7 @@
 {% load staticfiles %}
 
 {% block sidebar %}
+  <form id="js-facet" action="{{ form_action }}" method="get">
 
   <div class="row">
 
@@ -31,5 +32,6 @@
   
   {% include "calisphere/forms/faceting.html" %}
   
+  </form>
   
 {% endblock %}

--- a/calisphere/templates/calisphere/searchResults.html
+++ b/calisphere/templates/calisphere/searchResults.html
@@ -53,8 +53,8 @@
     <!-- End Filters -->
 
       <div class="col-md-3 layout-col__2">
-        <form id="js-facet" action="{{ form_action }}" method="get">
         {% block sidebar %}
+          <form id="js-facet" action="{{ form_action }}" method="get">
           {% block refineSearch %}
 
             <!-- Begin Search Within Field -->
@@ -75,8 +75,8 @@
           <!-- Begin Checkbox Groups -->
           {% include "calisphere/forms/faceting.html" %}
           <!-- End Checkbox Groups -->
+          </form>
         {% endblock %}
-        </form>
       </div>
 
       <div class="col-md-9 layout-col__3">

--- a/calisphere/views.py
+++ b/calisphere/views.py
@@ -1022,6 +1022,7 @@ def collectionView(request, collection_id):
     fq.append('collection_url: "' + collection['url'] + '"')
 
     # Add Custom Facet Filter Types
+    facet_types = list(FACET_FILTER_TYPES)
     extra_facet_types = []
     if collection_details['custom_facet']:
         for i in range(len(collection_details['custom_facet'])):
@@ -1034,21 +1035,21 @@ def collectionView(request, collection_id):
 
         # Add custom facet only if doesn't already exist.
         [
-            FACET_FILTER_TYPES.append(facet) for facet in extra_facet_types
-            if facet not in FACET_FILTER_TYPES
+            facet_types.append(facet) for facet in extra_facet_types
+            if facet not in facet_types
         ]
 
     else:
         # If collection_details['custom_facet'] is empty, remove extra facet types from FACET_FILTER_TYPES.
-        if len(FACET_FILTER_TYPES) > len(DEFAULT_FACET_FILTER_TYPES):
+        if len(facet_types) > len(DEFAULT_FACET_FILTER_TYPES):
             [
-                FACET_FILTER_TYPES.remove(facet)
-                for facet in FACET_FILTER_TYPES
+                facet_types.remove(facet)
+                for facet in facet_types
                 if facet not in DEFAULT_FACET_FILTER_TYPES
             ]
 
     facet_fields = list(facet_filter_type['facet']
-                        for facet_filter_type in FACET_FILTER_TYPES
+                        for facet_filter_type in facet_types
                         if facet_filter_type['facet'] != 'collection_data')
 
     # perform the search
@@ -1108,7 +1109,7 @@ def collectionView(request, collection_id):
         'facets':
         facets,
         'FACET_FILTER_TYPES':
-        list(facet_filter_type for facet_filter_type in FACET_FILTER_TYPES
+        list(facet_filter_type for facet_filter_type in facet_types
              if facet_filter_type['facet'] != 'collection_data' and
              facet_filter_type['facet'] != 'repository_data'),
         'numFound':


### PR DESCRIPTION
Resolves several issues with custom facets. Removes session storage from the client side codebase to do so. 

One issue remains in that the carousel does not correctly display filtered search results when coming from a search on a collection page with a filter of a custom type applied. (IE, if you start at the Ramicova collection, filter on Aida, and then click into an object, the carousel at the top shows all items in the Ramicova collection, rather than all items in the Ramicova collection, Aida production). 

This is another 1-2 day fix, and seems significantly better than the current broken state of custom facets, so I'm submitting a pull request at this juncture. 