### PR TITLE
Fixed display issues for component level metadata Date and Place (UCLA)

### DIFF
--- a/calisphere/templates/calisphere/component-metadata-dd.html
+++ b/calisphere/templates/calisphere/component-metadata-dd.html
@@ -3,6 +3,11 @@
 {% if value|is_string %}
 {{ value }}
 {% else %}
-{% for v in value %}{{ v }} <br> {% endfor %}
+{% for v in value %}
+  {% if v.text %}
+    {{ v.text }}
+  {% else %}
+    {{ v }}
+  {% endif %} <br> {% endfor %}
 {% endif %}
 </dd>

--- a/calisphere/templates/calisphere/component-metadata.html
+++ b/calisphere/templates/calisphere/component-metadata.html
@@ -20,7 +20,11 @@
 
     {% if item.selectedComponent.date %}
       <dt class="meta-block__type">Date Created and/or Issued</dt>
-      {% include "calisphere/component-metadata-dd.html" with value=item.selectedComponent.date.0.displayDate %}
+      {% if item.selectedComponent.date.0.displayDate %}
+        {% include "calisphere/component-metadata-dd.html" with value=item.selectedComponent.date.0.displayDate %}
+      {% else %}
+        {% include "calisphere/component-metadata-dd.html" with value=item.selectedComponent.date %}
+      {% endif %}
     {% endif %}
 
     {% if item.selectedComponent.publisher %}


### PR DESCRIPTION
@tingletech made a commit two years ago specifying that for displaying "Date" at the component level, the template should look in the structmap for `date.0.displayDate` (https://github.com/ucldc/public_interface/commit/a1ef28b69c3a0810d48f825ec0e420e5665bc056) The date data in question for pivotal ticket #148795197 is not in fact in an array of dictionaries with a 'displayDate' key. Actually for the given object alone, there are several different format types for date: strings, numbers, and arrays of either strings or numbers. This pull request adds a conditional checking for a `date.0.displayDate`; if none is found, displays the contents of the date key in the structMap (arrays get line breaks between each array entry). 

For place, the template is expecting either a string, or an array of strings, and instead gets an array of dictionaries containing a 'text' key. This seems entirely unneccessary and like maybe it should be removed at the stage of creating the structMap. For now, though, I've added a conditional checking specifically for arrays of dictionaries with a 'text' key for component metadata field values. 

CSphere:
http://calisphere-test.cdlib.org/item/d3a5a28f-1781-4322-8629-899fca7cc3e1/?order=3

Nuxeo:
https://nuxeo.cdlib.org/nuxeo/nxdoc/default/561ed770-cd7e-4428-9042-b10eba16a60a/view_documents

Media.json
https://s3.amazonaws.com/static.ucldc.cdlib.org/media_json/d3a5a28f-1781-4322-8629-899fca7cc3e1-media.json