### PR TITLE
Fixes more like this results for the carousel

### DIFF
--- a/calisphere/views.py
+++ b/calisphere/views.py
@@ -500,7 +500,8 @@ def itemViewCarousel(request):
             extra_filter = 'campus_url: "https://registry.cdlib.org/api/v1/campus/' + campus_id + '/"'
 
     solrParams = solrEncode(params, facet_filter_types)
-    solrParams['fq'].append(extra_filter)
+    if extra_filter:
+        solrParams['fq'].append(extra_filter)
 
     #if no query string or filters, do a "more like this" search
     if solrParams['q'] == '' and len(solrParams['fq']) == 0:


### PR DESCRIPTION
Makes it so that `len(solrParams['fq'])` is actually 0 when it should be and not 1 due to an empty string (`extra_filter=''`). 