### PR TITLE
Icon of last resort

### DIFF
--- a/app/styles/_objects.scss
+++ b/app/styles/_objects.scss
@@ -42,9 +42,18 @@ html.no-jquery .obj__osd-infobanner {
   @include thumbnail__tile-icon(17vw, 11vw, 11vw, 130px); // for custom icon sizes instead of defaults at xs, sm, md, and lg screen sizes, add comma separated number/unit value in parentheses, like: (20vw, 10vw, 8vw, 80px)
 }
 
+.obj__tile-icon.movingimage { @extend .fa-play-circle-o; }
+.obj__tile-icon.sound { @extend .fa-volume-up; }
+.obj__tile-icon.text { @extend .fa-file-text-o; }
+.obj__tile-icon.dataset { @extend .fa-bar-chart; }
+
 .obj__overlay-icon {
   @include thumbnail__overlay-icon(); // for custom icon sizes instead of defaults at xs, sm, md, and lg screen sizes, add comma separated number/unit value in parentheses, like: (20vw, 10vw, 8vw, 80px)
 }
+
+.obj__overlay-icon.movingimage { @extend .fa-play-circle-o; }
+.obj__overlay-icon.sound { @extend .fa-volume-up; }
+.obj__overlay-icon.dataset { @extend .fa-bar-chart; }
 
 // ***** Global Object Styles ***** //
 

--- a/calisphere/templates/calisphere/objectViewer/complex-object.html
+++ b/calisphere/templates/calisphere/objectViewer/complex-object.html
@@ -65,6 +65,10 @@
           <div class="carousel-complex__thumbnail-container">
             <div class="carousel-complex__tile-icon fa-file-text-o"></div>
           </div>
+        {% else %}
+          <div class="carousel-complex__thumbnail-container">
+            <div class="carousel-complex__tile-icon fa-file"></div>
+          </div>
         {% endif %}
       </a>
       {# note that this conditional logic for whether or not to display a caption needs to match the logic for setting the context variable item.hasComponentCaptions in calisphere/views.py -- which is used above to to set the parent div class and determine how to position prev/next arrows on the slick carousel #}

--- a/calisphere/templates/calisphere/objectViewer/object-tiles-and-overlays.html
+++ b/calisphere/templates/calisphere/objectViewer/object-tiles-and-overlays.html
@@ -16,28 +16,14 @@
         {% endif %}
 
         {% if item.harvest_type == "harvested" %}
-          {% if item.type_ss.0|lower == "moving image" %}
-          <div class="obj__overlay-icon fa-play-circle-o"></div>
-          {% elif item.type_ss.0|lower == "sound"%}
-          <div class="obj__overlay-icon fa-volume-up"></div>
-          {# elif item.type_ss.0|lower == "text"#}
-          <!-- <div class="obj__overlay-icon fa-file-text-o"></div> -->
-          {% elif item.type_ss.0|lower == "dataset" %}
-          <div class="obj__overlay-icon fa-bar-chart"></div>
+          {% if item.type_ss.0|lower != "text" %}
+            <div class="obj__overlay-icon {{ item.type_ss.0|lower|cut:' '}}"></div>
           {% endif %}
         {% endif %}
       </div>
     {% else %}
       <div class="thumbnail__container">
-        {% if item.type_ss.0|lower == "moving image" %}
-        <div class="obj__tile-icon fa-play-circle-o"></div>
-        {% elif item.type_ss.0|lower == "sound"%}
-        <div class="obj__tile-icon fa-volume-up"></div>
-        {% elif item.type_ss.0|lower == "text"%}
-        <div class="obj__tile-icon fa-file-text-o"></div>
-        {% elif item.type_ss.0|lower == "dataset" %}
-        <div class="obj__tile-icon fa-bar-chart"></div>
-        {% endif %}
+        <div class="obj__tile-icon {{ item.type_ss.0|lower|cut:' '}}"></div>
       </div>
     {% endif %}
     <div class="obj__caption">


### PR DESCRIPTION
- Added an 'icon of last resort' to the item viewer in complex-object.html
- Moved logic for which icon to display out of the object-tiles-and-overlays.html
template and into the stylesheet

- If type_ss isn't one of the values explicitly specified in the stylesheet, no icon will appear. This is the current (desirable?) behavior anyway, though. 