### PR TITLE
bug fixes, GA feature

### DIFF
--- a/app/scripts/calisphere.js
+++ b/app/scripts/calisphere.js
@@ -185,11 +185,13 @@ $(document).on('ready pjax:end', function() {
     var dim1 = $('[data-ga-dim1]').data('ga-dim1');
     var dim2 = $('[data-ga-dim2]').data('ga-dim2');
     var dim3 = Modernizr.sessionstorage.toString();
+    var dim4 = $('[data-ga-dim4]').data('ga-dim4');
 
     ga('set', 'location', window.location.href);
     if (dim1) { ga('set', 'dimension1', dim1); }
     if (dim2) { ga('set', 'dimension2', dim2); }
     if (dim3) { ga('set', 'dimension3', dim3); }
+    if (dim4) { ga('set', 'dimension4', dim4); }
     ga('send', 'pageview');
     if (inst_ga_code) {
       var inst_tracker_name = inst_ga_code.replace(/-/g,'x');

--- a/app/styles/_objects.scss
+++ b/app/styles/_objects.scss
@@ -58,6 +58,7 @@ html.no-jquery .obj__osd-infobanner {
 .obj__overlay-icon.movingimage { @extend .fa-play-circle-o; }
 .obj__overlay-icon.sound { @extend .fa-volume-up; }
 .obj__overlay-icon.dataset { @extend .fa-bar-chart; }
+.obj__overlay-icon.image { display: none; }
 
 // ***** Global Object Styles ***** //
 

--- a/calisphere/templates/calisphere/collectionView.html
+++ b/calisphere/templates/calisphere/collectionView.html
@@ -64,7 +64,7 @@
         <a class="collection-intro__about-link" href="{{ collection.url_local }}" target="_blank">View this collection on the contributor's website.</a><br/>
       {% endif %}
       {% if collection.url_oac|length > 0 %}
-        <a class="collection-intro__about-link" href="{{ collection.url_oac }}" target="_blank">View finding aid.</a>
+        <a class="collection-intro__about-link" href="{{ collection.url_oac }}" target="_blank">View collection guide.</a>
       {% endif %}
       <label for="{{ collection_id }}" aria-hidden="true" style="display: none;">Current Collection ID</label>
       <input id="{{ collection_id }}" class="facet js-facet facet-collection_data" form="js-facet" type="checkbox" name="collection_data" value="{{ collection_id }}" checked style="display: none;" aria-hidden="true">

--- a/calisphere/templates/calisphere/item-metadata.html
+++ b/calisphere/templates/calisphere/item-metadata.html
@@ -55,6 +55,7 @@
           data-pjax="js-pageContent"
           class="js-relatedCollection"
           data-ga-dim1="{{ collection.local_id }}{{ collection.slug }}"
+          data-ga-dim4="{{ collection.harvest_type }}"
         >{{ collection.name }}</a> <br> {% endfor %}</dd>
     {% endif %}
 

--- a/calisphere/templates/calisphere/item-metadata.html
+++ b/calisphere/templates/calisphere/item-metadata.html
@@ -138,14 +138,18 @@
     {% if 'relation' in item %}
 			<dt class="meta-block__type">Relation</dt>
 			<dd class="meta-block__defin">{% for relation in item.relation %}
+        {% if item.parsed_collection_data.0.custom_facet.0.facet_field == 'relation_ss' %}
         <a
           href="{% url 'calisphere:collectionView' item.parsed_collection_data.0.id %}?relation_ss={{ relation }}"
           data-relation="{{ relation }}"
           data-pjax="js-pageContent"
           class="js-relatedCollection"
-          data-ga-dim1="{{ item.parsed_collection_data.0.local_id }}{{ item.parsed_collection_data.0.slug }}"
         >
-        {{ relation }}</a><br> {% endfor %}</dd>
+        {% endif %}
+        {{ relation }}
+        {% if item.parsed_collection_data.0.custom_facet.0.facet_field == 'relation_ss' %}
+        </a>
+        {% endif %}<br> {% endfor %}</dd>
 		{% endif %}
 
     {% if 'provenance' in item %}

--- a/calisphere/views.py
+++ b/calisphere/views.py
@@ -49,6 +49,7 @@ def getMoreCollectionData(collection_data):
     collection['local_id'] = collection_details['local_id']
     collection['slug'] = collection_details['slug']
     collection['harvest_type'] = collection_details['harvest_type']
+    collection['custom_facet'] = collection_details['custom_facet']
 
     production_disqus = settings.UCLDC_FRONT == 'https://calisphere.org/' or settings.UCLDC_DISQUS == 'prod'
     if production_disqus:


### PR DESCRIPTION
Creates a 'harvest source' GA dimension on item pages
Removes white 'type' circle in lower left corner for harvested images on item pages
Removes relation link on item pages for items in collections which have not turned on a custom facet 
Changes 'View finding aid' language to 'View collection guide' language on a collection page. 

Pivotal tickets: 
https://www.pivotaltracker.com/story/show/152726965
https://www.pivotaltracker.com/story/show/157270712
https://www.pivotaltracker.com/story/show/157270207
https://www.pivotaltracker.com/story/show/157787166