### PR TITLE
Fixed broken link in "Terms of Use" page

### DIFF
--- a/calisphere/templates/calisphere/termsOfUse.html
+++ b/calisphere/templates/calisphere/termsOfUse.html
@@ -31,7 +31,7 @@
 <p>When citing or using material from the site, please provide information about the item so that others can learn more about and return to the original. Include the name of the contributing institution, a link to the item, and title and date information when available. Click the "get citation" button on a given item to easily find this information. You can then use your preferred style guide for formatting the citation. The Library of Congress provides additional guidance on <a href="http://www.loc.gov/teachers/usingprimarysources/citing.html">citing primary sources.</a></p>
 
 		<h2>What you can do with item information</h2>
-<p>Metadata on Calisphere, which is the factual information describing items on the site, can be freely shared and reused. <a href="https://registry.cdlib.org/documentation/docs/registry/access-policies/">Learn more</a>.
+<p>Metadata on Calisphere, which is the factual information describing items on the site, can be freely shared and reused. <a href="https://help.oac.cdlib.org/support/solutions/articles/9000081702-calisphere-policies">Learn more</a>.
 </p>
 
 		<h2>Know something we don't?</h2>


### PR DESCRIPTION
Fixed last link, to point to https://help.oac.cdlib.org/support/solutions/articles/9000081702-calisphere-policies