### PR TITLE
Resolves complex carousel jump to last item bug & produces a report of all exhibit items

### DIFF
--- a/app/scripts/ComplexCarouselView.js
+++ b/app/scripts/ComplexCarouselView.js
@@ -131,9 +131,9 @@ var ComplexCarouselView = Backbone.View.extend({
     $('.carousel-complex').show();
     $('.carousel-complex__item-container').slick(this.carouselConfig);
     if ($('.carousel-complex__item--selected').length > 0) {
-      $('.carousel-complex__item-container').slick('slickGoTo', $('.carousel-complex__item--selected').data('slick-index'));
+      $('.carousel-complex__item-container').slick('slickGoTo', $('.carousel-complex__item--selected .carousel-complex__link').data('item_id'));
     } else if ($('.carousel-complex__tile--selected').length > 0) {
-      $('.carousel-complex__item-container').slick('slickGoTo', $('.carousel-complex__tile--selected').data('slick-index'));
+      $('.carousel-complex__item-container').slick('slickGoTo', $('.carousel-complex__tile--selected .carousel-complex__link').data('item_id'));
     }
   },
 

--- a/exhibits/models.py
+++ b/exhibits/models.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 from builtins import object
 import os.path
+import sys
 
 from django.contrib.auth.models import User
 from django.db import models
@@ -439,6 +440,18 @@ class Theme(models.Model):
     def __str__(self):
         return self.title
 
+class PublishedExhibitItemManager(models.Manager):
+    def get_queryset(self):
+        if settings.EXHIBIT_PREVIEW:
+            return super(PublishedExhibitItemManager, self).get_queryset()
+        else:
+            exhibit_items = super(PublishedExhibitItemManager, self).get_queryset()
+            excludes = []
+            for exhibit_item in exhibit_items:
+                if not exhibit_item.solrData() and not exhibit_item.custom_crop:
+                    excludes.append(exhibit_item.id)
+            return exhibit_items.exclude(id__in=excludes)
+
 @python_2_unicode_compatible
 class ExhibitItem(models.Model):
     item_id = models.CharField(max_length=200)
@@ -464,6 +477,9 @@ class ExhibitItem(models.Model):
     lon = models.FloatField(default=-122.2675416)
     place = models.CharField(max_length=512, blank=True)
     exact = models.BooleanField(default=False)
+
+    objects = PublishedExhibitItemManager()
+
     def __str__(self):
         return self.item_id
 

--- a/exhibits/models.py
+++ b/exhibits/models.py
@@ -439,18 +439,6 @@ class Theme(models.Model):
     def __str__(self):
         return self.title
 
-class PublishedExhibitItemManager(models.Manager):
-    def get_queryset(self):
-        if settings.EXHIBIT_PREVIEW:
-            return super(PublishedExhibitItemManager, self).get_queryset()
-        else:
-            exhibit_items = super(PublishedExhibitItemManager, self).get_queryset()
-            excludes = []
-            for exhibit_item in exhibit_items:
-                if not exhibit_item.solrData() and not exhibit_item.custom_crop:
-                    excludes.append(exhibit_item.id)
-            return exhibit_items.exclude(id__in=excludes)
-
 @python_2_unicode_compatible
 class ExhibitItem(models.Model):
     item_id = models.CharField(max_length=200)
@@ -476,8 +464,6 @@ class ExhibitItem(models.Model):
     lon = models.FloatField(default=-122.2675416)
     place = models.CharField(max_length=512, blank=True)
     exact = models.BooleanField(default=False)
-
-    objects = PublishedExhibitItemManager()
 
     def __str__(self):
         return self.item_id

--- a/exhibits/models.py
+++ b/exhibits/models.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 from builtins import object
 import os.path
-import sys
 
 from django.contrib.auth.models import User
 from django.db import models

--- a/exhibits/templates/exhibits/exhibit_items.html
+++ b/exhibits/templates/exhibits/exhibit_items.html
@@ -1,5 +1,6 @@
 <div class="row primarysource">
   {% for item in exhibitItems %}
+    {% if item.solrData or item.custom_crop or item.custom_title %}
     <div class="col-xs-6 col-sm-3 col-md-2">
         <a class="primarysource__link js-exhibit-item" href="{% url url_name url_id item.item_id %}" title="{% if item.solrData %}{{ item.solrData.title.0 }}{% else %}{{ item.custom_title }}{% endif %}">
 
@@ -53,6 +54,7 @@
         </div>
         </a>
     </div>
+    {% endif %}
 
     {% if forloop.counter == 12 %}
       <div class="js-exhibit-items-overflow hidden-content">

--- a/exhibits/templates/exhibits/exhibit_items.html
+++ b/exhibits/templates/exhibits/exhibit_items.html
@@ -1,6 +1,5 @@
 <div class="row primarysource">
   {% for item in exhibitItems %}
-    {% if item.solrData or item.custom_crop or item.custom_title %}
     <div class="col-xs-6 col-sm-3 col-md-2">
         <a class="primarysource__link js-exhibit-item" href="{% url url_name url_id item.item_id %}" title="{% if item.solrData %}{{ item.solrData.title.0 }}{% else %}{{ item.custom_title }}{% endif %}">
 
@@ -54,7 +53,6 @@
         </div>
         </a>
     </div>
-    {% endif %}
 
     {% if forloop.counter == 12 %}
       <div class="js-exhibit-items-overflow hidden-content">

--- a/exhibits/urls.py
+++ b/exhibits/urls.py
@@ -11,5 +11,6 @@ urlpatterns = [
     url(r'^(?P<exhibit_id>\d+)/(?P<exhibit_slug>[-\w]+)/$', views.exhibitView, name='exhibitView'),
     url(r'^(?P<exhibit_id>\d+)/items/(?P<item_id>.+)/$', views.itemView, name='itemView'),
     url(r'^essay/(?P<essay_id>\d+)/(?P<essay_slug>[-\w]+)/$', views.essayView, name='essayView'),
-    url(r'^t(?P<theme_id>\d+)/(?P<theme_slug>[-_\w]+)/$', views.themeView, name='themeView')
+    url(r'^t(?P<theme_id>\d+)/(?P<theme_slug>[-_\w]+)/$', views.themeView, name='themeView'),
+    url(r'^exhibitReport/$', views.exhibitItemView, name='exhibitReport')
 ]

--- a/exhibits/views.py
+++ b/exhibits/views.py
@@ -4,7 +4,6 @@ from builtins import range
 from django.shortcuts import get_object_or_404, render, redirect
 from django.http import HttpResponse
 from django.core.exceptions import ObjectDoesNotExist
-from django.db.models import Q
 from exhibits.models import *
 from itertools import chain
 from django.conf import settings
@@ -176,11 +175,7 @@ def exhibitView(request, exhibit_id, exhibit_slug):
     if exhibit_slug != exhibit.slug:
         return redirect(exhibit)
 
-    all_exhibitItems = exhibit.exhibititem_set.all().order_by('order')
-    exhibitItems = []
-    for exhibitItem in all_exhibitItems:
-        if (exhibitItem.solrData() != None or exhibitItem.custom_title != ''):
-            exhibitItems.append(exhibitItem)
+    exhibitItems = exhibit.exhibititem_set.all().order_by('order')
 
     exhibitListing = []
     for theme in exhibit.published_themes().all():

--- a/exhibits/views.py
+++ b/exhibits/views.py
@@ -176,7 +176,6 @@ def exhibitView(request, exhibit_id, exhibit_slug):
         return redirect(exhibit)
 
     exhibitItems = exhibit.exhibititem_set.all().order_by('order')
-
     exhibitListing = []
     for theme in exhibit.published_themes().all():
         exhibits = theme.theme.published_exhibits().exclude(exhibit=exhibit).order_by('order')

--- a/exhibits/views.py
+++ b/exhibits/views.py
@@ -179,8 +179,7 @@ def exhibitView(request, exhibit_id, exhibit_slug):
     all_exhibitItems = exhibit.exhibititem_set.all().order_by('order')
     exhibitItems = []
     for exhibitItem in all_exhibitItems:
-        if (exhibitItem.solrData != None or exhibitItem.custom_title != '' or
-            exhibitItem.custom_crop != '' or exhibitItem.custom_metadata != ''):
+        if (exhibitItem.solrData() != None or exhibitItem.custom_title != ''):
             exhibitItems.append(exhibitItem)
 
     exhibitListing = []

--- a/exhibits/views.py
+++ b/exhibits/views.py
@@ -175,7 +175,7 @@ def exhibitView(request, exhibit_id, exhibit_slug):
     if exhibit_slug != exhibit.slug:
         return redirect(exhibit)
 
-    exhibitItems = exhibit.exhibititem_set.all().order_by('order')
+    exhibitItems = exhibit.exhibititem_set.filter(Q(solrData__isnull=False) | Q(custom_title__isnull=False)).order_by('order')
     exhibitListing = []
     for theme in exhibit.published_themes().all():
         exhibits = theme.theme.published_exhibits().exclude(exhibit=exhibit).order_by('order')

--- a/exhibits/views.py
+++ b/exhibits/views.py
@@ -4,6 +4,7 @@ from builtins import range
 from django.shortcuts import get_object_or_404, render, redirect
 from django.http import HttpResponse
 from django.core.exceptions import ObjectDoesNotExist
+from django.db.models import Q
 from exhibits.models import *
 from itertools import chain
 from django.conf import settings
@@ -175,7 +176,13 @@ def exhibitView(request, exhibit_id, exhibit_slug):
     if exhibit_slug != exhibit.slug:
         return redirect(exhibit)
 
-    exhibitItems = exhibit.exhibititem_set.filter(Q(solrData__isnull=False) | Q(custom_title__isnull=False)).order_by('order')
+    all_exhibitItems = exhibit.exhibititem_set.all().order_by('order')
+    exhibitItems = []
+    for exhibitItem in all_exhibitItems:
+        if (exhibitItem.solrData != None or exhibitItem.custom_title != '' or
+            exhibitItem.custom_crop != '' or exhibitItem.custom_metadata != ''):
+            exhibitItems.append(exhibitItem)
+
     exhibitListing = []
     for theme in exhibit.published_themes().all():
         exhibits = theme.theme.published_exhibits().exclude(exhibit=exhibit).order_by('order')


### PR DESCRIPTION
Resolves: 
https://www.pivotaltracker.com/story/show/158264229
- uses a model manager to filter out items without solr data AND without a custom crop. Items like this one, which isn't in Solr, but does have a custom image and metadata still show: http://calisphere.org/exhibitions/88/items/ark:/13030/hb067n98xg/%3Forder=3/ - this 'custom image' workaround exists for component objects of complex objects which are in OAC but not in Calisphere. 
- these objects aren't filtered out of display on 52.34.222.95 - so we can still see them there and maintain some awareness of them. 

https://www.pivotaltracker.com/story/show/158499249
- I updated slick awhile ago, but didn't realize they had changed some of their class names with the update. Removed dependency on slick-generated class names. 