### PR TITLE
tweak boost vector (query time)

### DIFF
--- a/calisphere/cache_retry.py
+++ b/calisphere/cache_retry.py
@@ -24,6 +24,7 @@ if hasattr(settings,'XRAY_RECORDER'):
     patch(('requests',))
 
 SOLR_DEFAULTS = {
+    'qf': 'title^10 description^5 subject^2',
     'mm': '100%',
     'pf3': 'title',
     'pf': 'text,title',


### PR DESCRIPTION
Is it possible to exclude the &quot;Publication Information&quot; line metadata from your keyword searching?

The presence of this metadata makes it nearly impossible to find views of the Berkeley campus:

Publication Information: The Bancroft Library. University of California, Berkeley 

(I was assisting a library user trying to find a known image, with the words: University Berkeley Watkins.   I couldn&#39;t find the images with this search because they were buried in non-Berkeley views by Watkins.)