### PR TITLE
Aeon Integration

### DIFF
--- a/calisphere/constants.py
+++ b/calisphere/constants.py
@@ -99,6 +99,12 @@ def getRepositoryData(repository_data=None, repository_id=None, repository_url=N
     # details needed for stats
     repository['ga_code'] = repository_details.get(
         'google_analytics_tracking_code', None)
+
+    production_aeon = settings.UCLDC_FRONT == 'https://calisphere.org/'
+    if production_aeon:
+        repository['aeon_url'] = repository_details.get('aeon_prod', None)
+    else:
+        repository['aeon_url'] = repository_details.get('aeon_test', None)
     parent = repository_details['campus']
     pslug = ''
     if len(parent):

--- a/calisphere/templates/calisphere/itemButtons.html
+++ b/calisphere/templates/calisphere/itemButtons.html
@@ -10,15 +10,14 @@
       </div>
       <div class="modal-body">
         <textarea style="width: 100%; height: 11em;" onclick="this.focus();this.select()">
-          Title: {{ item.title.0 }}{% if 'date' in item and item.date.0 %}
-          Date: {{ item.date.0 }}{% endif %}
-          Collection: {{ item.collection_name.0 }}
-          Owning Institution: {% if item.parsed_repository_data %}{% if item.parsed_repository_data.0.campus %}{{ item.parsed_repository_data.0.campus }}, {% endif %}{{ item.parsed_repository_data.0.name }}{% else %}{{ item.repository_name.0 }}
-          {% endif %}
-          Source: Calisphere
-          Date of access: {% now "F j Y H:i" %}
-          Permalink: {{ permalink }}
-        </textarea>
+Title: {{ item.title.0 }}{% if 'date' in item and item.date.0 %}
+Date: {{ item.date.0 }}{% endif %}
+Collection: {{ item.collection_name.0 }}
+Owning Institution: {% if item.parsed_repository_data %}{% if item.parsed_repository_data.0.campus %}{{ item.parsed_repository_data.0.campus }}, {% endif %}{{ item.parsed_repository_data.0.name }}{% else %}{{ item.repository_name.0 }}
+{% endif %}
+Source: Calisphere
+Date of access: {% now "F j Y H:i" %}
+Permalink: {{ permalink }}</textarea>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>

--- a/calisphere/templates/calisphere/itemButtons.html
+++ b/calisphere/templates/calisphere/itemButtons.html
@@ -137,12 +137,12 @@ Permalink: {{ permalink }}</textarea>
         <h4 class="modal-title" id="requestModalTitle">Request Item</h4>
       </div>
       <div class="modal-body">
-        <p>Requests to view the original item or obtain copies of it must be made through Aeon, {% if repository.campus %}{{ repository.campus }}, {% endif %}{{ repository.name }}'s request system. Sign up for a free Aeon account to create a request for the item by clicking the link below. You can use Aeon to schedule an in-person visit at {% if repository.campus %}{{ repository.campus }}, {% endif %}{{ repository.name }} to see the original item, or place an order to obtain a photocopy or a digital copy.</p>
+        <p>Requests to view the original item or obtain copies of it must be made through Aeon, {% if repository.campus %}{{ repository.campus }}, {% endif %}{{ repository.name }}'s request system. Sign up for a free Aeon account to create a request for the item by clicking the button below. You can use Aeon to schedule an in-person visit at {% if repository.campus %}{{ repository.campus }}, {% endif %}{{ repository.name }} to see the original item, or place an order to obtain a photocopy or a digital copy.</p>
         <p>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-        <a type="button" class="btn btn-primary" href="{{ repository.aeon_url }}&CallNumber={{ item.identifier|join:', ' }}&rft.title={{ item.title.0 }}&rft.date={{ item.date|join:', ' }}">Request Item through Aeon</a>
+        <a type="button" class="btn btn-primary" href="{{ repository.aeon_url }}&CallNumber={{ item.identifier|join:', ' }}&rft.title={{ item.collection_name.0 }}: {{ item.title.0 }}&ItemInfo1={{ item.title.0 }}">Request Item through Aeon</a>
       </div>
     </div>
   </div>
@@ -215,7 +215,7 @@ Permalink: {{ permalink }}</textarea>
         <!-- <span class="fa fa-exchange"></span> -->
         <!-- <span class="fa fa-archive"></span> -->
         <!-- <span class="fa fa-print"></span> -->
-      </span> Request {% if 'structMap' in item %}{{ item.contentFile.format }}{% else %}{{ item.type.0 }}{% endif %}
+      </span> Request {% if 'structMap' in item %}{{ item.contentFile.format }}{% elif item.type.0 == 'sound' %}item{% else %}{{ item.type.0 }}{% endif %}
     </a>
     {% endif %}
 

--- a/calisphere/templates/calisphere/itemButtons.html
+++ b/calisphere/templates/calisphere/itemButtons.html
@@ -143,7 +143,7 @@
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-        <a type="button" class="btn btn-primary" href="{{ repository.aeon_url }}">Request Item through Aeon</a>
+        <a type="button" class="btn btn-primary" href="{{ repository.aeon_url }}?&Action=10&Form=30&CallNumber={{ item.identifier|join:', ' }}&rft.title={{ item.title.0 }}&rft.date={{ item.date|join:', ' }}">Request Item through Aeon</a>
       </div>
     </div>
   </div>

--- a/calisphere/templates/calisphere/itemButtons.html
+++ b/calisphere/templates/calisphere/itemButtons.html
@@ -10,14 +10,15 @@
       </div>
       <div class="modal-body">
         <textarea style="width: 100%; height: 11em;" onclick="this.focus();this.select()">
-Title: {{ item.title.0 }}{% if 'date' in item and item.date.0 %}
-Date: {{ item.date.0 }}{% endif %}
-Collection: {{ item.collection_name.0 }}
-Owning Institution: {% if item.parsed_repository_data %}{% if item.parsed_repository_data.0.campus %}{{ item.parsed_repository_data.0.campus }}, {% endif %}{{ item.parsed_repository_data.0.name }}{% else %}{{ item.repository_name.0 }}
-{% endif %}
-Source: Calisphere
-Date of access: {% now "F j Y H:i" %}
-Permalink: {{ permalink }}</textarea>
+          Title: {{ item.title.0 }}{% if 'date' in item and item.date.0 %}
+          Date: {{ item.date.0 }}{% endif %}
+          Collection: {{ item.collection_name.0 }}
+          Owning Institution: {% if item.parsed_repository_data %}{% if item.parsed_repository_data.0.campus %}{{ item.parsed_repository_data.0.campus }}, {% endif %}{{ item.parsed_repository_data.0.name }}{% else %}{{ item.repository_name.0 }}
+          {% endif %}
+          Source: Calisphere
+          Date of access: {% now "F j Y H:i" %}
+          Permalink: {{ permalink }}
+        </textarea>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
@@ -127,6 +128,29 @@ Permalink: {{ permalink }}</textarea>
   </div>
 </div>
 
+{% if item.parsed_repository_data.0.aeon_url %}
+{% with item.parsed_repository_data.0 as repository %}
+<div class="modal fade" id="requestModal" tabindex="-1" role="dialog" aria-labelledby="requestModalTitle">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title" id="requestModalTitle">Request Item</h4>
+      </div>
+      <div class="modal-body">
+        <p>Requests to view the original item or obtain copies of it must be made through Aeon, {% if repository.campus %}{{ repository.campus }}, {% endif %}{{ repository.name }}'s request system. Sign up for a free Aeon account to create a request for the item by clicking the link below. You can use Aeon to schedule an in-person visit at {% if repository.campus %}{{ repository.campus }}, {% endif %}{{ repository.name }} to see the original item, or place an order to obtain a photocopy or a digital copy.</p>
+        <p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+        <a type="button" class="btn btn-primary" href="{{ repository.aeon_url }}">Request Item through Aeon</a>
+      </div>
+    </div>
+  </div>
+</div>
+{% endwith %}
+{% endif %}
+
 {% if item.harvest_type == 'hosted' %}
 <div class="modal fade" id="downloadModal" tabindex="-1" role="dialog" aria-labelledby="downloadModalTitle">
   <div class="modal-dialog" role="document">
@@ -151,7 +175,7 @@ Permalink: {{ permalink }}</textarea>
           {# {% endif %} #}
           <a type="button" class="btn btn-primary" href="{{ item.contentFile.url }}" download="{{ item.title.0 }}.jpg" target="_blank">Download</a>
         {% elif item.contentFile.format == 'file' or item.contentFile.format == 'audio' or item.contentFile.format == 'video'%}
-          <a type="button" class="btn btn-primary" href="{{ ucldcMedia }}{{ item.contentFile.id }}" target="_blank">Download</a>
+          <a type="button" class="btn btn-primary" href="{{ ucldcMedia }}{{ item.contentFile.id }}" download target="_blank">Download</a>
         {% else %}
           <a type="button" class="btn btn-primary" href="">Download</a>
         {% endif %}
@@ -184,6 +208,17 @@ Permalink: {{ permalink }}</textarea>
       <span class="fa fa-envelope"></span>
       Contact Owner
     </a>
+
+    {% if item.parsed_repository_data.0.aeon_url %}
+    <a class="btn btn-xs obj-buttons__download-image" href="javascript: void(0)" data-toggle="modal" data-target="#requestModal">
+      <span class="icon__download-image">
+        <!-- <span class="fa fa-external-link"></span> -->
+        <!-- <span class="fa fa-exchange"></span> -->
+        <!-- <span class="fa fa-archive"></span> -->
+        <!-- <span class="fa fa-print"></span> -->
+      </span> Request {% if 'structMap' in item %}{{ item.contentFile.format }}{% else %}{{ item.type.0 }}{% endif %}
+    </a>
+    {% endif %}
 
     {% if item.harvest_type == 'hosted' %}
       {% if 'structMap' in item and 'contentFile' in item and item.contentFile.format == 'file' %}

--- a/calisphere/templates/calisphere/itemButtons.html
+++ b/calisphere/templates/calisphere/itemButtons.html
@@ -142,7 +142,7 @@ Permalink: {{ permalink }}</textarea>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-        <a type="button" class="btn btn-primary" href="{{ repository.aeon_url }}?&Action=10&Form=30&CallNumber={{ item.identifier|join:', ' }}&rft.title={{ item.title.0 }}&rft.date={{ item.date|join:', ' }}">Request Item through Aeon</a>
+        <a type="button" class="btn btn-primary" href="{{ repository.aeon_url }}&CallNumber={{ item.identifier|join:', ' }}&rft.title={{ item.title.0 }}&rft.date={{ item.date|join:', ' }}">Request Item through Aeon</a>
       </div>
     </div>
   </div>

--- a/calisphere/views.py
+++ b/calisphere/views.py
@@ -393,7 +393,7 @@ def itemView(request, item_id=''):
                 getMoreCollectionData(collection_data))
         for repository_data in item.get('repository_data'):
             z = getRepositoryData(repository_data=repository_data).copy()
-            z.update({'aeon_url': 'https://google.com'})
+            z.update({'aeon_url': 'http://training5.atlas-sys.com/aeon/aeon.dll'})
             item['parsed_repository_data'].append(z)
             # getRepositoryData(repository_data=repository_data)
             print(z)

--- a/calisphere/views.py
+++ b/calisphere/views.py
@@ -392,8 +392,11 @@ def itemView(request, item_id=''):
             item['parsed_collection_data'].append(
                 getMoreCollectionData(collection_data))
         for repository_data in item.get('repository_data'):
-            item['parsed_repository_data'].append(
-                getRepositoryData(repository_data=repository_data))
+            z = getRepositoryData(repository_data=repository_data).copy()
+            z.update({'aeon_url': 'https://google.com'})
+            item['parsed_repository_data'].append(z)
+            # getRepositoryData(repository_data=repository_data)
+            print(z)
 
             institution_url = item['parsed_repository_data'][0]['url']
             institution_details = json_loads_url(institution_url +

--- a/calisphere/views.py
+++ b/calisphere/views.py
@@ -392,11 +392,8 @@ def itemView(request, item_id=''):
             item['parsed_collection_data'].append(
                 getMoreCollectionData(collection_data))
         for repository_data in item.get('repository_data'):
-            z = getRepositoryData(repository_data=repository_data).copy()
-            z.update({'aeon_url': 'http://training5.atlas-sys.com/aeon/aeon.dll'})
-            item['parsed_repository_data'].append(z)
-            # getRepositoryData(repository_data=repository_data)
-            print(z)
+            item['parsed_repository_data'].append(
+                getRepositoryData(repository_data=repository_data))
 
             institution_url = item['parsed_repository_data'][0]['url']
             institution_details = json_loads_url(institution_url +


### PR DESCRIPTION
- Changes to `constants.py` pipes registry fields `aeon_prod` or `aeon_test` to `registry_data`
- Changes to `itemButtons.html` adds a button below an item view between 'Contact Owner' (appears on all pages) and 'Download' (only appears for hosted items), adds a modal popup when that button is clicked, and adds an Aeon URL to the modal. 

Need to check with Adrian that including an item's 'type' value on the button is okay (see Pivotal: https://www.pivotaltracker.com/story/show/160765514/comments/195344632 - image vs. text) and the URL is okay - maybe should just include Call Number, not Call Number, Title, and Date.