### PR TITLE
Deploy Redirects to Calisphere

### DIFF
--- a/.ebextensions/01syncdb.config
+++ b/.ebextensions/01syncdb.config
@@ -16,6 +16,8 @@ container_commands:
     command: "python manage.py loaddata fixtures/sites.json"
   05sitemaps:
     command: "python manage.py calisphere_refresh_sitemaps --settings public_interface.settings"
+  06redirects:
+    command: "httxt2dbm -i CSPHERE_IDS.txt -o CSPHERE_IDS.map"
 
 files:
   "/opt/elasticbeanstalk/hooks/configdeploy/post/01load-content.sh": &file

--- a/.ebextensions/01syncdb.config
+++ b/.ebextensions/01syncdb.config
@@ -17,7 +17,7 @@ container_commands:
   05sitemaps:
     command: "python manage.py calisphere_refresh_sitemaps --settings public_interface.settings"
   06redirects:
-    command: "httxt2dbm -i CSPHERE_IDS.txt -o CSPHERE_IDS.map"
+    command: "./fetch-redirects.sh"
 
 files:
   "/opt/elasticbeanstalk/hooks/configdeploy/post/01load-content.sh": &file
@@ -27,6 +27,7 @@ files:
     content: |
         #!/bin/env bash
         /opt/python/current/app/load-content.sh
+        /opt/python/current/app/fetch-redirects.sh
 
 # http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/create_deploy_Python_django.html
 

--- a/.ebextensions/customize_wsgi.config
+++ b/.ebextensions/customize_wsgi.config
@@ -18,6 +18,7 @@ files:
           WSGI_STAGING_CONFIG = config.get_container_config('wsgi_staging_config')
           config.execute(['mkdir', '-p', '/etc/httpd/wsgi.conf.d'])
           config.execute(['sed', '-i', 's,wsgi processes=,wsgi maximum-requests=1000 processes=,g', WSGI_STAGING_CONFIG])
+          config.execute(['sed', '-i', '/\<VirtualHost \*:80\>/a IncludeOptional /etc/httpd/wsgi.conf.d/*.conf', WSGI_STAGING_CONFIG])
         except Exception, e:
           config.emit_error_event(config.USER_ERROR_MESSAGES['badappconfig'])
           config.diagnostic('Error patching wsgi.conf during configdeploy/pre: %s' % str(e))
@@ -27,3 +28,13 @@ files:
         config.configure_stdout_logger()
         main()
   "/opt/elasticbeanstalk/hooks/appdeploy/pre/99patchwsgi.py": *file
+
+  "/etc/httpd/wsgi.conf.d/redirects.conf":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+        RewriteEngine On
+        RewriteMap csphereids "dbm:/opt/python/current/app/CSPHERE_IDS.map"
+        RewriteCond ${csphereids:$1|NOT} !=NOT
+        RewriteRule ^/item/(.*)/$ /item/${csphereids:$1} [R]

--- a/.ebextensions/customize_wsgi.config
+++ b/.ebextensions/customize_wsgi.config
@@ -37,4 +37,4 @@ files:
         RewriteEngine On
         RewriteMap csphereids "dbm:/opt/python/current/app/CSPHERE_IDS.map"
         RewriteCond ${csphereids:$1|NOT} !=NOT
-        RewriteRule ^/item/(.*)/$ /item/${csphereids:$1}/ [R]
+        RewriteRule ^/item/(.*)/$ ${csphereids:$1} [R]

--- a/.ebextensions/customize_wsgi.config
+++ b/.ebextensions/customize_wsgi.config
@@ -37,4 +37,4 @@ files:
         RewriteEngine On
         RewriteMap csphereids "dbm:/opt/python/current/app/CSPHERE_IDS.map"
         RewriteCond ${csphereids:$1|NOT} !=NOT
-        RewriteRule ^/item/(.*)/$ /item/${csphereids:$1} [R]
+        RewriteRule ^/item/(.*)/$ /item/${csphereids:$1}/ [R]

--- a/app/styles/_objects.scss
+++ b/app/styles/_objects.scss
@@ -59,6 +59,8 @@ html.no-jquery .obj__osd-infobanner {
 .obj__overlay-icon.sound { @extend .fa-volume-up; }
 .obj__overlay-icon.dataset { @extend .fa-bar-chart; }
 .obj__overlay-icon.image { display: none; }
+.obj__overlay-icon.physicalobject { display: none; }
+.obj__overlay.interactiveresource { display: none; }
 
 // ***** Global Object Styles ***** //
 

--- a/calisphere/templates/calisphere/objectViewer/object-tiles-and-overlays.html
+++ b/calisphere/templates/calisphere/objectViewer/object-tiles-and-overlays.html
@@ -42,6 +42,8 @@
           View dataset
         {% elif item.type_ss.0|lower == "image" %}
           View source image
+        {% else %}
+          View source
         {% endif %}
          on
         {% if item.oac == True %}

--- a/calisphere/templates/contact_form/contact_form.html
+++ b/calisphere/templates/contact_form/contact_form.html
@@ -31,7 +31,7 @@
         <strong>
           Last page viewed:
         </strong> {{ request.META.HTTP_REFERER }}
-        <input type="hidden" name="referer" value="{{ request.META.HTTP_REFERER }}">
+        <input type="hidden" name="referer" value="{{ request.META.HTTP_REFERER }}"/>
       </div>
 <p>*If this message concerns items or collections found on this site, please contact the <a href="/institutions/" data-pjax="js-pageContent">contributing institution</a> directly. Messages about items or collections submitted through this page may be forwarded to the contributing institution, as noted in our <a href="/privacy/" data-pjax="js-pageContent">Privacy Statement</a>.</p>
   <div class="form-group">
@@ -60,6 +60,7 @@
         </ul>
 
   </div>
+</div>
 {% endblock %}
 
 {% block footerScripts %}

--- a/deploy-version.sh
+++ b/deploy-version.sh
@@ -46,7 +46,7 @@ ZIP="ucldc-$1.zip"
 gulp
 
 # package app and upload
-zip $ZIP -r calisphere/ load-content.sh manage.py public_interface/ test/ requirements.txt README.md .ebextensions/ dist/ exhibits/ fixtures/
+zip $ZIP -r calisphere/ load-content.sh CSPHERE_IDS.txt manage.py public_interface/ test/ requirements.txt README.md .ebextensions/ dist/ exhibits/ fixtures/
 aws s3 cp $ZIP s3://$BUCKET/$DIR/$ZIP
 aws elasticbeanstalk create-application-version \
   --application-name $APPNAME \

--- a/deploy-version.sh
+++ b/deploy-version.sh
@@ -46,7 +46,7 @@ ZIP="ucldc-$1.zip"
 gulp
 
 # package app and upload
-zip $ZIP -r calisphere/ load-content.sh CSPHERE_IDS.txt manage.py public_interface/ test/ requirements.txt README.md .ebextensions/ dist/ exhibits/ fixtures/
+zip $ZIP -r calisphere/ load-content.sh manage.py public_interface/ test/ requirements.txt README.md .ebextensions/ dist/ exhibits/ fixtures/
 aws s3 cp $ZIP s3://$BUCKET/$DIR/$ZIP
 aws elasticbeanstalk create-application-version \
   --application-name $APPNAME \

--- a/deploy-version.sh
+++ b/deploy-version.sh
@@ -46,7 +46,7 @@ ZIP="ucldc-$1.zip"
 gulp
 
 # package app and upload
-zip $ZIP -r calisphere/ load-content.sh manage.py public_interface/ test/ requirements.txt README.md .ebextensions/ dist/ exhibits/ fixtures/
+zip $ZIP -r calisphere/ load-content.sh fetch-redirects.sh manage.py public_interface/ test/ requirements.txt README.md .ebextensions/ dist/ exhibits/ fixtures/
 aws s3 cp $ZIP s3://$BUCKET/$DIR/$ZIP
 aws elasticbeanstalk create-application-version \
   --application-name $APPNAME \

--- a/fetch-redirects.sh
+++ b/fetch-redirects.sh
@@ -11,24 +11,23 @@ set -o errexit   ## set -e : exit the script if any statement returns a non-true
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" # http://stackoverflow.com/questions/59895
 cd $DIR
 
-usage(){
-    echo "fetch-redirects.sh version-label"
-    exit 1
-}
-
-if [ $# -ne 1 ];
+if [[ -e /opt/python/current/env ]]
   then
-    usage
+    set +u
+    source /opt/python/current/env
+    set -u
 fi
 
-set -u
-
-DIR=redirects
-BUCKET=static-ucldc-cdlib-org
 REGION=us-west-2
-REDIRECTS="$1.txt"
+filename="${UCLDC_REDIRECT_IDS##*/}"         # http://unix.stackexchange.com/a/64435/40198
+name=$(echo $filename | rev | cut -c 4- | rev )  # http://stackoverflow.com/a/5863742/1763984
 
-aws s3 cp s3://$BUCKET/$DIR/$REDIRECTS CSPHERE_IDS.txt
+if [[ ! -e $name ]]  # have we seen this one before
+  then
+    aws s3 cp $UCLDC_REDIRECT_IDS .
+    httxt2dbm -i $filename -o CSPHERE_IDS.map
+  fi
+
 
 # Copyright (c) 2015, Regents of the University of California
 #

--- a/fetch-redirects.sh
+++ b/fetch-redirects.sh
@@ -21,7 +21,7 @@ fi
 REGION=us-west-2
 filename="${UCLDC_REDIRECT_IDS##*/}"         # http://unix.stackexchange.com/a/64435/40198
 
-if [[ ! -e $filename ]]  # have we seen this one before
+if [[ ! -e $filename && ! -z $UCLDC_REDIRECT_IDS ]]  # have we seen this one before
   then
     aws s3 cp $UCLDC_REDIRECT_IDS .
     httxt2dbm -i $filename -o CSPHERE_IDS.map

--- a/fetch-redirects.sh
+++ b/fetch-redirects.sh
@@ -1,0 +1,60 @@
+#!/bin/env bash
+if [[ -n "$DEBUG" ]]; then
+  set -x
+fi
+
+set -o pipefail  # trace ERR through pipes
+set -o errtrace  # trace ERR through 'time command' and other functions
+set -o nounset   ## set -u : exit the script if you try to use an uninitialised variable
+set -o errexit   ## set -e : exit the script if any statement returns a non-true return value
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" # http://stackoverflow.com/questions/59895
+cd $DIR
+
+usage(){
+    echo "fetch-redirects.sh version-label"
+    exit 1
+}
+
+if [ $# -ne 1 ];
+  then
+    usage
+fi
+
+set -u
+
+DIR=redirects
+BUCKET=static-ucldc-cdlib-org
+REGION=us-west-2
+REDIRECTS="$1.txt"
+
+aws s3 cp s3://$BUCKET/$DIR/$REDIRECTS CSPHERE_IDS.txt
+
+# Copyright (c) 2015, Regents of the University of California
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# - Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+# - Neither the name of the University of California nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.

--- a/fetch-redirects.sh
+++ b/fetch-redirects.sh
@@ -21,7 +21,7 @@ fi
 REGION=us-west-2
 filename="${UCLDC_REDIRECT_IDS##*/}"         # http://unix.stackexchange.com/a/64435/40198
 
-if [[ ! -e $filename && ! -z $UCLDC_REDIRECT_IDS ]]  # have we seen this one before
+if [[ ! -e $filename ]]  # have we seen this one before
   then
     aws s3 cp $UCLDC_REDIRECT_IDS .
     httxt2dbm -i $filename -o CSPHERE_IDS.map

--- a/fetch-redirects.sh
+++ b/fetch-redirects.sh
@@ -20,9 +20,8 @@ fi
 
 REGION=us-west-2
 filename="${UCLDC_REDIRECT_IDS##*/}"         # http://unix.stackexchange.com/a/64435/40198
-name=$(echo $filename | rev | cut -c 4- | rev )  # http://stackoverflow.com/a/5863742/1763984
 
-if [[ ! -e $name ]]  # have we seen this one before
+if [[ ! -e $filename ]]  # have we seen this one before
   then
     aws s3 cp $UCLDC_REDIRECT_IDS .
     httxt2dbm -i $filename -o CSPHERE_IDS.map


### PR DESCRIPTION
Follows the exhibition data pattern to maintain separation of code and redirects table updates
- Use environment variable `UCLDC_REDIRECT_IDS` to store s3 url of the redirects text file in the format `<old id> <new id>\n`
- On app deploy (via `container_commands`) and on environment variable update (via `/opt/elasticbeanstalk/hooks/configdeploy/post/01load-content.sh`), fetch text file and run `httxt2dbm` to generate `CSPHERE_IDS.map` files
- Use these files in `/etc/httpd/wsgi.conf.d/redirects.conf` to write redirect rules which are included in `wsgi.conf` via sed modification of `wsgi.conf`to `IncludeOptional wsgi.conf.d/*.conf` files (per already linked stackoverflow)