### PR TITLE
Update privacy policy link in text

### DIFF
--- a/calisphere/templates/calisphere/privacyStatement.html
+++ b/calisphere/templates/calisphere/privacyStatement.html
@@ -12,7 +12,7 @@
 
   <div class="col-sm-8 static__main">
 
-		<p>The California Digital Library (CDL) is committed to protecting your privacy to the greatest extent possible, subject to provisions of state and federal law. While our systems gather a variety of user information in the normal course of providing services, this information is kept for limited purposes only. For a detailed description of what information we collect from visitors to this website and how it is used and managed, please see the CDL Privacy Policy and Baseline Supporting Practices listed at <a href="http://www.cdlib.org/about/policies.html">http://www.cdlib.org/about/policies.html</a>.</p>
+		<p>The California Digital Library (CDL) is committed to protecting your privacy to the greatest extent possible, subject to provisions of state and federal law. While our systems gather a variety of user information in the normal course of providing services, this information is kept for limited purposes only. For a detailed description of what information we collect from visitors to this website and how it is used and managed, please see the <a href="https://cdlib.org/about/policies-and-guidelines/privacy-policy/">CDL Privacy Policy and Baseline Supporting Practices</a>.</p>
 
 		<h2>Addendum</h2>
 


### PR DESCRIPTION
Updated the CDL Privacy Policy link on the first paragraph, to point from http://www.cdlib.org/about/policies.html (page not found)
to https://cdlib.org/about/policies-and-guidelines/privacy-policy/