### PR TITLE
Revert "Removed session storage warning"

### DIFF
--- a/app/scripts/calisphere.js
+++ b/app/scripts/calisphere.js
@@ -6,6 +6,23 @@
 // Cope with browser variance
 // --------------------------
 
+// Called on document ready, adds banner notice
+// to DOM for users without session storage
+function sessionStorageWarning() {
+  if (! Modernizr.sessionstorage) {
+    $('body').prepend(
+      $('<div/>', {'class': 'container-fluid'})
+      .append(
+        $('<div/>', {
+          'class': 'alert alert-warning alert-dismissible',
+          'role': 'alert'
+        }).text('Some features on the Calisphere beta site do not yet work in private browsing mode. For an optimal experience, please disable private browsing while on this site.')
+        .append('<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>')
+      )
+    );
+  }
+}
+
 // For IE
 if(typeof console === 'undefined') {
   console = { log: function() { } };
@@ -62,6 +79,10 @@ $(document).ready(function() {
       return false;
     });
   }
+  // ***********************************
+
+  // Add banner notice for users without session storage
+  sessionStorageWarning();
   // ***********************************
 
   // **Window Resize Tracking**
@@ -174,7 +195,7 @@ var on_ready_pjax_end_handler = function() {
     var inst_ga_code = $('[data-ga-code]').data('ga-code');
     var dim1 = $('[data-ga-dim1]').data('ga-dim1');
     var dim2 = $('[data-ga-dim2]').data('ga-dim2');
-    // var dim3 = Modernizr.sessionstorage.toString();
+    var dim3 = Modernizr.sessionstorage.toString();
     var dim4 = $('[data-ga-dim4]').data('ga-dim4');
 
     ga('set', 'location', window.location.href);


### PR DESCRIPTION
This reverts commit f62fb0b3620c231a0af4f4d2290a05f8fa98dd79.

We no longer use session storage, so this check is pretty pointless, and it's the only Calisphere javascript dependency of `Modernizr.js`. I think it's only still around so the google analytics don't get confused? 

I'd been attempting to remove it though, because we now use the calisphere.js file on registry for the exhibitions pages. In order to not get a javascript error, we *also* need to include the `Modernizr.js` file because of this check. But then that caused some JS errors on production, so now I'm putting it back, at least for now, till I can remove it correctly. 