### PR TITLE
collectstatics needs to be in pre and post deploy

### DIFF
--- a/.platform/hooks/postdeploy/managecmd.sh
+++ b/.platform/hooks/postdeploy/managecmd.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+source /var/app/venv/*/bin/activate
+echo "starting collect statics";
+python manage.py collectstatic --noinput
+echo "starting site maps";
+python manage.py calisphere_refresh_sitemaps --settings public_interface.settings
+


### PR DESCRIPTION
collectstatics needs to be in pre and post deploy to prevent static file errors after deployment as well as after server restart.