### PR TITLE
1. Updates the OpenSearch integration to Calisphere

### DIFF
--- a/calisphere/collection_views.py
+++ b/calisphere/collection_views.py
@@ -144,7 +144,7 @@ class Collection(object):
         self.custom_schema_facets = self._generate_custom_schema_facets()
 
         if index == 'es':
-            self.basic_filter = {'collection_ids': [self.id]}
+            self.basic_filter = {'collection_url': [self.id]}
         else:
             self.basic_filter = {'collection_url': [self.url]}
 

--- a/calisphere/es_cache_retry.py
+++ b/calisphere/es_cache_retry.py
@@ -52,9 +52,7 @@ def es_search(body):
 
     for result in results['hits']['hits']:
         metadata = result.pop('_source')
-        metadata['title'] = [metadata.get('title')]
-        metadata['type'] = [metadata.get('type')]
-        metadata['type_ss'] = [metadata.get('type')]
+        metadata['type_ss'] = metadata.get('type')
         result.update(metadata)
 
     results = ESResults(

--- a/calisphere/es_cache_retry.py
+++ b/calisphere/es_cache_retry.py
@@ -186,7 +186,7 @@ def query_encode(query_string: str = None,
                 es_params['query'] = es_filters[0]
 
     if facets:
-        exceptions = ['collection_ids', 'repository_ids', 'campus_ids']
+        exceptions = ['collection_url', 'repository_url', 'campus_url']
         aggs = {}
         for facet in facets:
             if facet in exceptions or facet[-8:] == '.keyword':

--- a/calisphere/institution_views.py
+++ b/calisphere/institution_views.py
@@ -45,25 +45,16 @@ def process_sort_collection_data(string):
 @cache_by_session_state
 def campus_directory(request):
     index = request.session.get("index", "solr")
-    if index == 'es':
-        repo_query = {
-            "facets": ['repository_url']
-        }
-    else:
-        repo_query = {
-            "facets": ['repository_url']
-        }
+    repo_query = {"facets": ['repository_url']}
     repo_search = ItemManager(index).search(repo_query)
 
     repositories = []
-    if index == 'es':
-        index_repositories = repo_search.facet_counts['facet_fields'][
-            'repository_url']
-    else:
-        index_repositories = repo_search.facet_counts['facet_fields'][
-            'repository_url']
+    index_repositories = repo_search.facet_counts['facet_fields'][
+        'repository_url']
+
+    if index != 'es':
         index_repositories = [re.match(repo_regex, repo_url).group(
-            'repository_url') for repo_url in index_repositories]
+            'repository_id') for repo_url in index_repositories]
 
     for repo_id in index_repositories:
         repository = Repository(repo_id, index).get_repo_data()
@@ -93,22 +84,13 @@ def campus_directory(request):
 @cache_by_session_state
 def statewide_directory(request):
     index = request.session.get("index", "solr")
-    if index == 'es':
-        repo_query = {
-            "facets": ['repository_url']
-        }
-    else:
-        repo_query = {
-            "facets": ['repository_url']
-        }
+    repo_query = {"facets": ['repository_url']}
 
     repo_search = ItemManager(index).search(repo_query)
-    if index == 'es':
-        index_repositories = repo_search.facet_counts['facet_fields'][
-            'repository_url']
-    else:
-        index_repositories = repo_search.facet_counts['facet_fields'][
-            'repository_url']
+    index_repositories = repo_search.facet_counts['facet_fields'][
+        'repository_url']
+
+    if index != 'es':
         index_repositories = [re.match(repo_regex, repo_url).group(
             'repository_id') for repo_url in index_repositories]
 

--- a/calisphere/institution_views.py
+++ b/calisphere/institution_views.py
@@ -47,7 +47,7 @@ def campus_directory(request):
     index = request.session.get("index", "solr")
     if index == 'es':
         repo_query = {
-            "facets": ['repository_ids']
+            "facets": ['repository_url']
         }
     else:
         repo_query = {
@@ -58,12 +58,12 @@ def campus_directory(request):
     repositories = []
     if index == 'es':
         index_repositories = repo_search.facet_counts['facet_fields'][
-            'repository_ids']
+            'repository_url']
     else:
         index_repositories = repo_search.facet_counts['facet_fields'][
             'repository_url']
         index_repositories = [re.match(repo_regex, repo_url).group(
-            'repository_id') for repo_url in index_repositories]
+            'repository_url') for repo_url in index_repositories]
 
     for repo_id in index_repositories:
         repository = Repository(repo_id, index).get_repo_data()
@@ -95,7 +95,7 @@ def statewide_directory(request):
     index = request.session.get("index", "solr")
     if index == 'es':
         repo_query = {
-            "facets": ['repository_ids']
+            "facets": ['repository_url']
         }
     else:
         repo_query = {
@@ -105,7 +105,7 @@ def statewide_directory(request):
     repo_search = ItemManager(index).search(repo_query)
     if index == 'es':
         index_repositories = repo_search.facet_counts['facet_fields'][
-            'repository_ids']
+            'repository_url']
     else:
         index_repositories = repo_search.facet_counts['facet_fields'][
             'repository_url']
@@ -178,7 +178,7 @@ class Campus(object):
             self.contact_info = ''
 
         if index == 'es':
-            self.basic_filter = {'campus_ids': [self.id]}
+            self.basic_filter = {'campus_url': [self.id]}
         else:
             self.basic_filter = {'campus_url': [self.url]}
 
@@ -213,7 +213,7 @@ class Repository(object):
                 self.featured_image = feat[0].get('featuredImage')
 
         if index == 'es':
-            self.basic_filter = {'repository_ids': [self.id]}
+            self.basic_filter = {'repository_url': [self.id]}
         else:
             self.basic_filter = {'repository_url': [self.url]}
 

--- a/public_interface/settings.py
+++ b/public_interface/settings.py
@@ -44,6 +44,7 @@ SOLR_API_KEY = getenv('UCLDC_SOLR_API_KEY', '')
 ES_HOST = getenv('ES_HOST', '')
 ES_USER = getenv('ES_USER', '')
 ES_PASS = getenv('ES_PASS', '')
+ES_ALIAS = getenv('ES_ALIAS', '')
 
 
 UCLDC_IMAGES = getenv('UCLDC_IMAGES', '')


### PR DESCRIPTION
1) Makes necessary changes to use index aliases: 
- can't use `elasticsearch.get` - must use `.search` instead
- adds `ES_ALIAS` to settings. 

2) Updates fields from the prototype schema to our actual schema:
- we don't have `*_id` fields like we did in the prototype index - we have `*_url` fields. The `*_url` fields have numerical ids in them, like they did in the prototype index, not url fields, like they do in the solr index, so facet requests look the same from solr to opensearch, but filter requests look differently. 
- these `*_url` fields are also keyword fields, unlike they were in the prototype index, so we don't need to exclude them from keyword faceting. 
- we don't have the `word_bucket` field like we did in the prototype index, so we don't need to remove it to make the record look more like a solr record
- `title` is a list, like it was in Solr, but unlike it was in the prototype index, no need to convert it to a list anymore
- `type` is a list, like it was in Solr, but unlike it was in the prototype index, no need to convert it to a list anymore
- `type_ss` doesn't exist on the index but is critical to the UI, so we do still need to create it (clean this up later)
- `source` is a list, like it was in Solr, but unlike it was in the prototype index, no need to convert it to a list
- `location` is a list, like it was in Solr, but unlike in the prototype index, no need to convert it to a list either
