### PR TITLE
Opensearch query updates

### DIFF
--- a/calisphere/collection_views.py
+++ b/calisphere/collection_views.py
@@ -161,10 +161,10 @@ class Collection(object):
                         {
                             'form_name': custom_facet['facet_field'],
                             'facet_field': (
-                                f"{custom_facet['facet_field'][:-3]}.keyword"),
+                                f"{custom_facet['facet_field'][:-3]}.raw"),
                             'display_name': custom_facet['label'],
                             'filter_field': (
-                                f"{custom_facet['facet_field'][:-3]}.keyword"),
+                                f"{custom_facet['facet_field'][:-3]}.raw"),
                             'sort_by': custom_facet['sort_by'],
                             'faceting_allowed': True
                         }
@@ -310,7 +310,7 @@ class Collection(object):
                 repositories.append(repository['name'])
 
         if self.index == 'es':
-            sort = ("sort_title.keyword", "asc")
+            sort = ("sort_title.raw", "asc")
         else:
             sort = ("sort_title", "asc")
 

--- a/calisphere/constants.py
+++ b/calisphere/constants.py
@@ -36,7 +36,32 @@ SORT_OPTIONS = {
 FacetDisplay = namedtuple(
     'FacetDisplay', 'facet, display')
 
-# solr schema fields that have a `_ss` varient for facets
+# index schema fields that are of type=keyword so we can get
+# facets directly without needing an _ss or .raw suffix
+UCLDC_SCHEMA_TERM_FIELDS = [
+    'calisphere-id',
+    'id',
+    'campus_name',
+    'campus_data',
+    'campus_url',
+    'campus_id',
+    'collection_name',
+    'collection_data',
+    'collection_url',
+    'collection_id',
+    'sort_collection_data',
+    'repository_name',
+    'repository_data',
+    'repository_url',
+    'repository_id',
+    'rights_uri',
+    'url_item',
+    'fetcher_type',
+    'mapper_type'
+]
+
+# index schema fields that are of type=text and thus need a 
+# solr _ss or opensearch .raw suffix to get facets
 UCLDC_SCHEMA_FACETS = [
   FacetDisplay("title", "title"),
   FacetDisplay("alternative_title", "alternative title"),
@@ -70,7 +95,7 @@ UCLDC_SOLR_SCHEMA_FACETS = [
     for fd in UCLDC_SCHEMA_FACETS
 ]
 UCLDC_ES_SCHEMA_FACETS = [
-    FacetDisplayField(fd.facet, fd.display, f"{fd.facet}.keyword")
+    FacetDisplayField(fd.facet, fd.display, f"{fd.facet}.raw")
     for fd in UCLDC_SCHEMA_FACETS
 ]
 

--- a/calisphere/es_cache_retry.py
+++ b/calisphere/es_cache_retry.py
@@ -241,11 +241,30 @@ def query_encode(query_string: str = None,
                 es_params['query'] = es_filters[0]
 
     if facets:
-        # exceptions = ['collection_url', 'repository_url', 'campus_url']
-        exceptions = []
+        keyword_fields = [
+            'calisphere-id',
+            'id',
+            'campus_name',
+            'campus_data',
+            'campus_url',
+            'campus_id',
+            'collection_name',
+            'collection_data',
+            'collection_url',
+            'collection_id',
+            'sort_collection_data',
+            'repository_name',
+            'repository_data',
+            'repository_url',
+            'repository_id',
+            'rights_uri',
+            'url_item',
+            'fetcher_type',
+            'mapper_type'
+        ]
         aggs = {}
         for facet in facets:
-            if facet in exceptions or facet[-8:] == '.keyword':
+            if facet in keyword_fields or facet[-8:] == '.keyword':
                 field = facet
             else:
                 field = f'{facet}.keyword'
@@ -283,6 +302,7 @@ def query_encode(query_string: str = None,
     es_params.update({'size': rows})
     if start:
         es_params.update({'from': start})
+
     return es_params
 
 

--- a/calisphere/es_cache_retry.py
+++ b/calisphere/es_cache_retry.py
@@ -303,6 +303,7 @@ def query_encode(query_string: str = None,
     if start:
         es_params.update({'from': start})
 
+    es_params.update({'track_total_hits': True})
     return es_params
 
 

--- a/calisphere/es_cache_retry.py
+++ b/calisphere/es_cache_retry.py
@@ -1,6 +1,7 @@
 """ logic for cache / retry for es (opensearch) and JSON from registry
 """
 
+from calisphere.constants import UCLDC_SCHEMA_TERM_FIELDS
 from future import standard_library
 from django.core.cache import cache
 from django.conf import settings
@@ -166,9 +167,9 @@ def es_mlt(item_id):
         "query": {
             "more_like_this": {
                 "fields": [
-                    "title.keyword",
+                    "title.raw",
                     "collection_data",
-                    "subject.keyword",
+                    "subject.raw",
                 ],
                 "like": [
                     {"_id": item_id}
@@ -241,33 +242,12 @@ def query_encode(query_string: str = None,
                 es_params['query'] = es_filters[0]
 
     if facets:
-        keyword_fields = [
-            'calisphere-id',
-            'id',
-            'campus_name',
-            'campus_data',
-            'campus_url',
-            'campus_id',
-            'collection_name',
-            'collection_data',
-            'collection_url',
-            'collection_id',
-            'sort_collection_data',
-            'repository_name',
-            'repository_data',
-            'repository_url',
-            'repository_id',
-            'rights_uri',
-            'url_item',
-            'fetcher_type',
-            'mapper_type'
-        ]
         aggs = {}
         for facet in facets:
-            if facet in keyword_fields or facet[-8:] == '.keyword':
+            if facet in UCLDC_SCHEMA_TERM_FIELDS or facet[-4:] == '.raw':
                 field = facet
             else:
-                field = f'{facet}.keyword'
+                field = f'{facet}.raw'
 
             aggs[facet] = {
                 "terms": {

--- a/calisphere/facet_filter_type.py
+++ b/calisphere/facet_filter_type.py
@@ -170,7 +170,7 @@ class ESRelationFF(ESFacetFilterType):
     form_name = 'relation_ss'
     facet_field = 'relation'
     display_name = 'Relation'
-    filter_field = 'relation.keyword'
+    filter_field = 'relation.raw'
     sort_by = 'value'
     faceting_allowed = False
 
@@ -186,7 +186,7 @@ class ESTypeFF(ESFacetFilterType):
     form_name = 'type_ss'
     facet_field = 'type'
     display_name = 'Type of Item'
-    filter_field = 'type.keyword'
+    filter_field = 'type.raw'
 
 
 class DecadeFF(FacetFilterType):
@@ -201,7 +201,7 @@ class ESDecadeFF(ESFacetFilterType):
     form_name = 'facet_decade'
     facet_field = 'date'
     display_name = 'Decade'
-    filter_field = 'date.keyword'
+    filter_field = 'date.raw'
     sort_by = 'value'
 
 

--- a/calisphere/search_form.py
+++ b/calisphere/search_form.py
@@ -10,7 +10,7 @@ def solr_escape(text):
 
 class SortField(object):
     default = 'relevance'
-    no_keyword = 'a'
+    default_without_query_string = 'a'
 
     def __init__(self, request):
         if (request.get('q')
@@ -18,7 +18,7 @@ class SortField(object):
            or request.getlist('fq')):
             self.sort = request.get('sort', self.default)
         else:
-            self.sort = request.get('sort', self.no_keyword)
+            self.sort = request.get('sort', self.default_without_query_string)
 
 
 class SearchForm(object):
@@ -389,7 +389,7 @@ class ESCampusCarouselForm(CampusCarouselForm):
 
 class AltSortField(SortField):
     default = 'oldest-end'
-    no_keyword = 'oldest-end'
+    default_without_query_string = 'oldest-end'
 
 
 class CollectionFacetValueForm(CollectionForm):


### PR DESCRIPTION
The main change here is adding `{'track_total_hits': True}` to opensearch queries. This solves the problem of getting back a hit total of 10,000 hits with a page of results.  (See https://github.com/ucldc/rikolti/issues/840).

It is apparently costly to search for all matches if the total hit count is very big, so ideally we would only add this parameter when necessary, i.e. to specific queries where we need to display an accurate hit count.

The other commit builds out the list of keyword fields in our opensearch mapping, which was necessary to get various search results pages working.