### PR TITLE
Download redirects in pre-deploy hook

### DIFF
--- a/.platform/hooks/predeploy/managecmd.sh
+++ b/.platform/hooks/predeploy/managecmd.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
 
 source /var/app/venv/*/bin/activate
+
 echo "starting collect statics";
 python manage.py collectstatic --noinput
 echo "finished collect statics";
+
+filename="${UCLDC_REDIRECT_IDS##*/}"
+echo "start downloading redirects from $UCLDC_REDIRECT_IDS to $(pwd)/$filename";
+aws s3 cp $UCLDC_REDIRECT_IDS .
+
+echo "download complete; creating redirect map";
+httxt2dbm -i $filename -o CSPHERE_IDS.map
+mv CSPHERE_IDS.map /var/app/
+
+echo "TODO: still need to create off-site redirect map OFF_CSPHERE.map"
+
+# echo "start creating off-site redirects";
+# httxt2dbm -i $filename -o OFF_CSPHERE.map
+# aws s3 cp s3://static-ucldc-cdlib-org/redirects/CSPHERE_IDS-2023-11-03.txt /var/app/current/redirects/ --recursive || true


### PR DESCRIPTION
This should alleviate some errors seen in `eb-engine.log` which may be causing beanstalk flailing: 

2024/04/14 06:29:55.759330 [INFO] AH00526: Syntax error on line 3 of /etc/httpd/conf.d/csphere_redirects.conf:
RewriteMap: file for map csphereids not found:/var/app/CSPHERE_IDS.map
