### PR TITLE
Fix Redirects

### DIFF
--- a/.platform/hooks/postdeploy/managecmd.sh
+++ b/.platform/hooks/postdeploy/managecmd.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
 source /var/app/venv/*/bin/activate
-echo "starting collect statics";
-python manage.py collectstatic --noinput
-echo "finished collect statics";
+echo "starting collectstatic";
+echo "post-deploy: python manage.py collectstatic --noinput" >> /var/log/collectstatic.log
+python manage.py collectstatic --noinput >> /var/log/collectstatic.log 2>&1
+echo "finished collectstatic";
+
 echo "start downloading sitemaps";
-aws s3 cp s3://static-ucldc-cdlib-org/sitemaps/2024-04-03-calisphere-prd/ /var/app/current/sitemaps/ --recursive || true
+sitemaps=s3://static-ucldc-cdlib-org/sitemaps/2024-04-03-calisphere-prd/
+echo "post-deploy: aws s3 cp $sitemaps /var/app/current/sitemaps/ --recursive" >> /var/log/s3_download.log
+aws s3 cp s3://static-ucldc-cdlib-org/sitemaps/2024-04-03-calisphere-prd/ /var/app/current/sitemaps/ --recursive || true >> /var/log/s3_download.log 2>&1
 echo "finished downloading sitemaps";

--- a/.platform/hooks/postdeploy/managecmd.sh
+++ b/.platform/hooks/postdeploy/managecmd.sh
@@ -9,5 +9,5 @@ echo "finished collectstatic";
 echo "start downloading sitemaps";
 sitemaps=s3://static-ucldc-cdlib-org/sitemaps/2024-04-03-calisphere-prd/
 echo "post-deploy: aws s3 cp $sitemaps /var/app/current/sitemaps/ --recursive" >> /var/log/s3_download.log
-aws s3 cp s3://static-ucldc-cdlib-org/sitemaps/2024-04-03-calisphere-prd/ /var/app/current/sitemaps/ --recursive || true >> /var/log/s3_download.log 2>&1
+aws s3 cp s3://static-ucldc-cdlib-org/sitemaps/2024-04-03-calisphere-prd/ /var/app/current/sitemaps/ --recursive >> /var/log/s3_download.log 2>&1 || true
 echo "finished downloading sitemaps";

--- a/.platform/hooks/predeploy/managecmd.sh
+++ b/.platform/hooks/predeploy/managecmd.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
 
 source /var/app/venv/*/bin/activate
+
 echo "starting collect statics";
 python manage.py collectstatic --noinput
 echo "finished collect statics";
+
+filename="${UCLDC_REDIRECT_IDS##*/}"
+echo "start downloading redirects from $UCLDC_REDIRECT_IDS to $(pwd)/$filename";
+aws s3 cp $UCLDC_REDIRECT_IDS .
+
+echo "download complete; creating redirect map";
+httxt2dbm -i $filename -o CSPHERE_IDS.map
+mv CSPHERE_IDS.map /var/app/
+
+echo "TODO: still need to create off-site redirect map OFF_CSPHERE.map"
+
+# echo "start creating off-site redirects";
+# httxt2dbm -i $filename -o OFF_CSPHERE.map
+# aws s3 cp s3://static-ucldc-cdlib-org/redirects/CSPHERE_IDS-2023-11-03.txt /var/app/current/redirects/ --recursive || true

--- a/.platform/hooks/predeploy/managecmd.sh
+++ b/.platform/hooks/predeploy/managecmd.sh
@@ -11,4 +11,6 @@ echo "download complete; creating redirect map";
 httxt2dbm -i $filename -o CSPHERE_IDS.map
 mv CSPHERE_IDS.map /var/app/
 
-echo "TODO: still need to create off-site redirect map OFF_CSPHERE.map"
+echo "create off-site redirect map";
+httxt2dbm -i off_csphere.txt -o OFF_CSPHERE.map
+mv OFF_CSPHERE.map /var/app/

--- a/.platform/hooks/predeploy/managecmd.sh
+++ b/.platform/hooks/predeploy/managecmd.sh
@@ -2,20 +2,13 @@
 
 source /var/app/venv/*/bin/activate
 
-echo "starting collect statics";
-python manage.py collectstatic --noinput
-echo "finished collect statics";
-
 filename="${UCLDC_REDIRECT_IDS##*/}"
 echo "start downloading redirects from $UCLDC_REDIRECT_IDS to $(pwd)/$filename";
-aws s3 cp $UCLDC_REDIRECT_IDS .
+echo "pre-deploy: aws s3 cp $UCLDC_REDIRECT_IDS . " >> /var/log/s3_download.log
+aws s3 cp $UCLDC_REDIRECT_IDS . >> /var/log/s3_download.log 2>&1
 
 echo "download complete; creating redirect map";
 httxt2dbm -i $filename -o CSPHERE_IDS.map
 mv CSPHERE_IDS.map /var/app/
 
 echo "TODO: still need to create off-site redirect map OFF_CSPHERE.map"
-
-# echo "start creating off-site redirects";
-# httxt2dbm -i $filename -o OFF_CSPHERE.map
-# aws s3 cp s3://static-ucldc-cdlib-org/redirects/CSPHERE_IDS-2023-11-03.txt /var/app/current/redirects/ --recursive || true


### PR DESCRIPTION
This alleviates some errors seen in eb-engine.log which seemed to be causing some amount of beanstalk flailing:

```
2024/04/11 10:21:29.931800 [INFO] Running command /bin/sh -c /usr/sbin/httpd -t -f /var/proxy/staging/httpd/conf/httpd.conf
2024/04/11 10:21:30.014107 [INFO] AH00526: Syntax error on line 3 of /etc/httpd/conf.d/csphere_redirects.conf:
RewriteMap: file for map csphereids not found:/var/app/CSPHERE_IDS.map

2024/04/11 10:21:30.015874 [ERROR] An error occurred during execution of command [self-startup] - [start 
proxy with new configuration]. Stop running the command. Error: copy proxy conf from staging failed 
with error validate httpd configuration failed with error Command /bin/sh -c /usr/sbin/httpd -t -f 
/var/proxy/staging/httpd/conf/httpd.conf failed with error exit status 1. Stderr:AH00526: Syntax error 
on line 3 of /etc/httpd/conf.d/csphere_redirects.conf:
RewriteMap: file for map csphereids not found:/var/app/CSPHERE_IDS.map```
