### PR TITLE
Copy .platform/hooks to new dir .platform/confighooks

### DIFF
--- a/.platform/confighooks/postdeploy/managecmd.sh
+++ b/.platform/confighooks/postdeploy/managecmd.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+source /var/app/venv/*/bin/activate
+echo "starting collectstatic";
+echo "post-deploy: python manage.py collectstatic --noinput" >> /var/log/collectstatic.log
+python manage.py collectstatic --noinput >> /var/log/collectstatic.log 2>&1
+echo "finished collectstatic";
+
+echo "start downloading sitemaps";
+sitemaps=s3://static-ucldc-cdlib-org/sitemaps/2024-04-03-calisphere-prd/
+echo "post-deploy: aws s3 cp $sitemaps /var/app/current/sitemaps/ --recursive" >> /var/log/s3_download.log
+aws s3 cp s3://static-ucldc-cdlib-org/sitemaps/2024-04-03-calisphere-prd/ /var/app/current/sitemaps/ --recursive >> /var/log/s3_download.log 2>&1 || true
+echo "finished downloading sitemaps";

--- a/.platform/confighooks/predeploy/managecmd.sh
+++ b/.platform/confighooks/predeploy/managecmd.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+source /var/app/venv/*/bin/activate
+
+echo "starting collectstatic";
+echo "pre-deploy: python manage.py collectstatic --noinput" >> /var/log/collectstatic.log
+python manage.py collectstatic --noinput >> /var/log/collectstatic.log 2>&1
+echo "finished collectstatic";
+
+filename="${UCLDC_REDIRECT_IDS##*/}"
+echo "start downloading redirects from $UCLDC_REDIRECT_IDS to $(pwd)/$filename";
+echo "pre-deploy: aws s3 cp $UCLDC_REDIRECT_IDS . " >> /var/log/s3_download.log
+aws s3 cp $UCLDC_REDIRECT_IDS . >> /var/log/s3_download.log 2>&1
+
+echo "download complete; creating redirect map";
+httxt2dbm -i $filename -o CSPHERE_IDS.map
+mv CSPHERE_IDS.map /var/app/
+
+echo "create off-site redirect map";
+httxt2dbm -i off_csphere.txt -o OFF_CSPHERE.map
+mv OFF_CSPHERE.map /var/app/


### PR DESCRIPTION
Based on this AWS post: https://repost.aws/knowledge-center/elastic-beanstalk-platform-hooks

Trying to avoid the problem where making a config change wipes out static files and they are not recreated.