### PR TITLE
Restore collectstatic to predploy hooks (again).

### DIFF
--- a/.platform/confighooks/predeploy/managecmd.sh
+++ b/.platform/confighooks/predeploy/managecmd.sh
@@ -2,6 +2,11 @@
 # NOTE: any changes made to this script should be copied to .platform/hooks/predeploy/managecmd.sh
 source /var/app/venv/*/bin/activate
 
+echo "starting collectstatic";
+echo "pre-deploy: python manage.py collectstatic --noinput" >> /var/log/collectstatic.log
+python manage.py collectstatic --noinput >> /var/log/collectstatic.log 2>&1
+echo "finished collectstatic";
+
 filename="${UCLDC_REDIRECT_IDS##*/}"
 echo "start downloading redirects from $UCLDC_REDIRECT_IDS to $(pwd)/$filename";
 echo "pre-deploy: aws s3 cp $UCLDC_REDIRECT_IDS . " >> /var/log/s3_download.log

--- a/.platform/hooks/predeploy/managecmd.sh
+++ b/.platform/hooks/predeploy/managecmd.sh
@@ -2,6 +2,11 @@
 # NOTE: any changes made to this script should be copied to .platform/confighooks/predeploy/managecmd.sh
 source /var/app/venv/*/bin/activate
 
+echo "starting collectstatic";
+echo "pre-deploy: python manage.py collectstatic --noinput" >> /var/log/collectstatic.log
+python manage.py collectstatic --noinput >> /var/log/collectstatic.log 2>&1
+echo "finished collectstatic";
+
 filename="${UCLDC_REDIRECT_IDS##*/}"
 echo "start downloading redirects from $UCLDC_REDIRECT_IDS to $(pwd)/$filename";
 echo "pre-deploy: aws s3 cp $UCLDC_REDIRECT_IDS . " >> /var/log/s3_download.log


### PR DESCRIPTION
Verified that we do need to run `manage.py collectstatic` as part of both the pre- and post-deploy hook scripts.