### PR TITLE
Add results sorting for OpenSearch queries

### DIFF
--- a/calisphere/collection_views.py
+++ b/calisphere/collection_views.py
@@ -307,7 +307,7 @@ class Collection(object):
                 repositories.append(repository['name'])
 
         if self.index == 'es':
-            sort = ("sort_title.raw", "asc")
+            sort = ("sort_title", "asc")
         else:
             sort = ("sort_title", "asc")
 

--- a/calisphere/collection_views.py
+++ b/calisphere/collection_views.py
@@ -306,11 +306,6 @@ class Collection(object):
             else:
                 repositories.append(repository['name'])
 
-        if self.index == 'es':
-            sort = ("sort_title", "asc")
-        else:
-            sort = ("sort_title", "asc")
-
         # get 6 image items from the collection for the mosaic preview
         search_terms = {
             "filters": [
@@ -325,7 +320,7 @@ class Collection(object):
                 CollectionFF.filter_field,
                 "type"
             ],
-            "sort": sort,
+            "sort": ("sort_title", "asc"),
             "rows": 6
         }
         display_items = ItemManager(self.index).search(search_terms)

--- a/calisphere/es_cache_retry.py
+++ b/calisphere/es_cache_retry.py
@@ -275,12 +275,12 @@ def query_encode(query_string: str = None,
             i = result_fields.index('type_ss')
             result_fields[i] = 'type'
 
-    # if sort:
-    #     es_params.update({
-    #         "sort": [{
-    #             sort[0]: {"order": sort[1]}
-    #         }]
-    #     })
+    if sort:
+        es_params.update({
+            "sort": [{
+            sort[0]: {"order": sort[1]}
+        }]
+    })
     
     es_params.update({'size': rows})
     if start:

--- a/calisphere/es_cache_retry.py
+++ b/calisphere/es_cache_retry.py
@@ -276,9 +276,13 @@ def query_encode(query_string: str = None,
             result_fields[i] = 'type'
 
     if sort:
+        if sort[0] == 'score':
+            sort_by = '_score'
+        else:
+            sort_by = sort[0]
         es_params.update({
             "sort": [{
-            sort[0]: {"order": sort[1]}
+            sort_by: {"order": sort[1]}
         }]
     })
     


### PR DESCRIPTION
This PR implements sorting search results for OpenSearch queries. Other than needing to change score to _score, I think all of the fields we sort on exist in the new index and are mapped as type keyword.

It looks like sorting by sort_date_start and sort_date_end works for the ETL'ed collections that have this field, fwiw. Of course it does nothing for non-ETLed collections right now.

@amywieliczka This is ready for review. I think I checked all of the relevant places where sorting is used, but please let me know if you can think of any gotchas.