### PR TITLE
Escape reserved chars for OpenSearch query_string query

### DIFF
--- a/calisphere/collection_views.py
+++ b/calisphere/collection_views.py
@@ -7,7 +7,7 @@ from . import constants
 from .facet_filter_type import FacetFilterType, TypeFF, CollectionFF
 from .utils import json_loads_url
 from .item_manager import ItemManager
-from .search_form import CollectionForm, ESCollectionForm, solr_escape
+from .search_form import CollectionForm, ESCollectionForm, query_string_escape
 from builtins import range
 from .decorators import cache_by_session_state
 
@@ -489,7 +489,7 @@ def collection_facet(request, collection_id, facet):
 
         values = values[start:end]
         for value in values:
-            escaped_cluster_value = solr_escape(value['label'])
+            escaped_cluster_value = query_string_escape(value['label'])
             thumb_params = {
                 "filters": [
                     collection.basic_filter, 
@@ -569,7 +569,7 @@ def collection_facet_value(request, collection_id, cluster, cluster_value):
         form = ESCollectionForm(request.GET.copy(), collection)
 
     parsed_cluster_value = urllib.parse.unquote_plus(cluster_value)
-    escaped_cluster_value = solr_escape(parsed_cluster_value)
+    escaped_cluster_value = query_string_escape(parsed_cluster_value)
     extra_filter = {cluster_type.field: [escaped_cluster_value]}
 
     form.implicit_filter.append(extra_filter)
@@ -633,7 +633,7 @@ def collection_metadata(request, collection_id):
 
 
 def get_cluster_thumbnails(collection, facet, facet_value, index):
-    escaped_cluster_value = solr_escape(facet_value)
+    escaped_cluster_value = query_string_escape(facet_value)
     thumb_params = {
         'filters': [
             collection.basic_filter,

--- a/calisphere/collection_views.py
+++ b/calisphere/collection_views.py
@@ -5,9 +5,9 @@ from django.http import Http404, JsonResponse
 from calisphere.collection_data import CollectionManager
 from . import constants
 from .facet_filter_type import FacetFilterType, TypeFF, CollectionFF
-from .utils import json_loads_url
+from .utils import json_loads_url, query_string_escape
 from .item_manager import ItemManager
-from .search_form import CollectionForm, ESCollectionForm, query_string_escape
+from .search_form import CollectionForm, ESCollectionForm
 from builtins import range
 from .decorators import cache_by_session_state
 

--- a/calisphere/facet_filter_type.py
+++ b/calisphere/facet_filter_type.py
@@ -4,6 +4,7 @@ import operator
 from django.apps import apps
 from django.conf import settings
 from .utils import json_loads_url
+from .utils import query_string_escape
 from calisphere.collection_data import CollectionManager
 
 # FACETS are retrieved from Solr for a user to potentially FILTER on
@@ -20,11 +21,6 @@ col_template = "https://registry.cdlib.org/api/v1/collection/{0}/"
 repo_regex = (
     r'^https://registry\.cdlib\.org/api/v1/repository/(?P<id>\d*)/?')
 repo_template = "https://registry.cdlib.org/api/v1/repository/{0}/"
-
-
-def solr_escape(text):
-    return text.replace('?', '\\?').replace('"', '\\"').replace(':', '\\:')
-
 
 class FacetFilterType(object):
     form_name = ''
@@ -47,7 +43,7 @@ class FacetFilterType(object):
         if len(selected_filters) > 0:
             query = list([
                 '{0}: "{1}"'.format(self.filter_field,
-                                    solr_escape(
+                                    query_string_escape(
                                         self.filter_transform(val)))
                 for val in selected_filters
             ])

--- a/calisphere/search_form.py
+++ b/calisphere/search_form.py
@@ -2,11 +2,7 @@ from . import constants
 from django.http import Http404
 from . import facet_filter_type as ff
 from .item_manager import ItemManager
-
-
-def solr_escape(text):
-    return text.replace('?', '\\?').replace('"', '\\"').replace(':', '\\:')
-
+from .utils import query_string_escape
 
 class SortField(object):
     default = 'relevance'
@@ -113,8 +109,8 @@ class SearchForm(object):
 
         # concatenate query terms from refine query and query box
         terms = (
-            [solr_escape(self.q)] +
-            [solr_escape(q) for q in self.rq] +
+            [query_string_escape(self.q)] +
+            [query_string_escape(q) for q in self.rq] +
             self.request.getlist('fq')
         )
         terms = [q for q in terms if q]

--- a/calisphere/utils.py
+++ b/calisphere/utils.py
@@ -28,3 +28,17 @@ def json_loads_url(url_or_req):
         except urllib.error.HTTPError:
             data = {}
     return data
+
+# Escape OpenSearch `query_string` query reserved characters
+# (Solr has a smaller, overlapping subset of special characters)
+# Exceptions:
+#  - we are allowing phrase queries surrounded by ""
+#  - we are allowing wildcard expressions using *
+def query_string_escape(text):
+    for reserved in ['\\', '+', '-', '=', '&&', '||',
+                     '!', '(', ')', '{', '}',
+                     '[', ']', '^', '~', '?',
+                     "'", ':', '/']:
+        text = text.replace(reserved, f'\\{reserved}')
+
+    return text

--- a/calisphere/views.py
+++ b/calisphere/views.py
@@ -8,7 +8,7 @@ from .utils import json_loads_url
 from .item_manager import ItemManager
 from .record import Record
 
-from .search_form import (SearchForm, ESSearchForm, query_string_escape,
+from .search_form import (SearchForm, ESSearchForm,
                           CollectionFacetValueForm, ESCollectionFacetValueForm,
                           CarouselForm, ESCarouselForm,
                           CollectionCarouselForm, ESCollectionCarouselForm,
@@ -23,6 +23,7 @@ from requests.exceptions import HTTPError
 from exhibits.models import ExhibitItem, Exhibit
 from .decorators import cache_by_session_state
 from django.views.decorators.cache import cache_page
+from .utils import query_string_escape
 
 import os
 import math

--- a/calisphere/views.py
+++ b/calisphere/views.py
@@ -8,7 +8,7 @@ from .utils import json_loads_url
 from .item_manager import ItemManager
 from .record import Record
 
-from .search_form import (SearchForm, ESSearchForm, solr_escape, 
+from .search_form import (SearchForm, ESSearchForm, query_string_escape,
                           CollectionFacetValueForm, ESCollectionFacetValueForm,
                           CarouselForm, ESCarouselForm,
                           CollectionCarouselForm, ESCollectionCarouselForm,
@@ -108,7 +108,7 @@ def item_view(request, item_id=''):
                     'calisphere:collectionView',
                     kwargs={'collection_id': item.collections[0].id}) +
                     "?relation_ss=" +
-                    urllib.parse.quote(solr_escape(relation)))
+                    urllib.parse.quote(query_string_escape(relation)))
                 })
         else:
             relation_links.append({
@@ -321,7 +321,7 @@ def get_related_collections(request):
     if not form.query_string and not rc_params.get('filters'):
         if request.GET.get('itemId'):
             rc_params['query_string'] = form.query_string = (
-                f"id:{solr_escape(request.GET.get('itemId'))}")
+                f"id:{query_string_escape(request.GET.get('itemId'))}")
 
     related_collections = ItemManager(index).search(rc_params)
     related_collections = related_collections.facet_counts['facet_fields'][
@@ -464,7 +464,7 @@ def report_collection_facet_value(request, collection_id, facet, facet_value):
         raise Http404("{} does not exist".format(facet))
 
     parsed_facet_value = urllib.parse.unquote_plus(facet_value)
-    escaped_facet_value = solr_escape(parsed_facet_value)
+    escaped_facet_value = query_string_escape(parsed_facet_value)
 
     if index == 'es':
         form = ESCollectionFacetValueForm(request.GET.copy(), collection)


### PR DESCRIPTION
This PR adds a function called `query_string_escape` to `utils`. This new function replaces `calisphere.facet_filter_type.solr_escape` and `calisphere.search_form.solr_escape`, which were identical.

Note that it does not escape double quotes (") or asterisks (*), since we do allow users to make use of these reserved characters: https://calisphere.org/help/#2

