### PR TITLE
Add boosting, minimum_should_match to query_string queries

### DIFF
--- a/calisphere/es_cache_retry.py
+++ b/calisphere/es_cache_retry.py
@@ -214,7 +214,13 @@ def query_encode(query_string: str = None,
     if query_string:
         es_query = [{
             "query_string": {
-                "query": query_string
+                "query": query_string,
+                "fields": [
+                    "title^2",
+                    "*"
+                ],
+                "default_operator": "AND",
+                "minimum_should_match": "100%"
             }
         }]
 


### PR DESCRIPTION
This PR attempts to configure OpenSearch queries in a way that mimics what we have configured for Solr queries. I honestly don't quite understand how to replicate it entirely, especially setting "slop" on words and phrases. Hopefully Amy and I will get some deeper insight into how to configure things in our class next week. I played around with searching using this configuration, and the results seem acceptable to me fwiw.

Note: we are using a `query_string` query for our search boxes, described here: https://opensearch.org/docs/2.11/query-dsl/full-text/query-string . As stated in this documentation, this kind of query isn't actually well suited to search box applications. But since we are allowing users to issue phrase queries (using double quotes) and wildcard queries (using *) via the search box, it seems like it makes sense to stick to this kind of query for MVP.