### PR TITLE
Add `analyzer: english` to query_string queries

### DIFF
--- a/calisphere/es_cache_retry.py
+++ b/calisphere/es_cache_retry.py
@@ -221,6 +221,7 @@ def query_encode(query_string: str = None,
                 ],
                 "default_operator": "AND",
                 "minimum_should_match": "100%"
+                "analyzer": "english"
             }
         }]
 


### PR DESCRIPTION
This will stem words at query time following english language rules. 