### PR TITLE
Sentry

### DIFF
--- a/.platform/confighooks/postdeploy/managecmd.sh
+++ b/.platform/confighooks/postdeploy/managecmd.sh
@@ -11,3 +11,6 @@ sitemaps=s3://static-ucldc-cdlib-org/sitemaps/2024-04-03-calisphere-prd/
 echo "post-deploy: aws s3 cp $sitemaps /var/app/current/sitemaps/ --recursive" >> /var/log/s3_download.log
 aws s3 cp s3://static-ucldc-cdlib-org/sitemaps/2024-04-03-calisphere-prd/ /var/app/current/sitemaps/ --recursive >> /var/log/s3_download.log 2>&1 || true
 echo "finished downloading sitemaps";
+
+export EB_ENVIRONMENT_NAME=$(/opt/elasticbeanstalk/bin/get-config container | jq .environment_name)
+export EB_APP_VERSION=$(jq '.RuntimeSources."eb-calisphere" | keys[0]' /opt/elasticbeanstalk/deployment/app_version_manifest.json)

--- a/.platform/hooks/postdeploy/managecmd.sh
+++ b/.platform/hooks/postdeploy/managecmd.sh
@@ -11,3 +11,6 @@ sitemaps=s3://static-ucldc-cdlib-org/sitemaps/2024-04-03-calisphere-prd/
 echo "post-deploy: aws s3 cp $sitemaps /var/app/current/sitemaps/ --recursive" >> /var/log/s3_download.log
 aws s3 cp s3://static-ucldc-cdlib-org/sitemaps/2024-04-03-calisphere-prd/ /var/app/current/sitemaps/ --recursive >> /var/log/s3_download.log 2>&1 || true
 echo "finished downloading sitemaps";
+
+export EB_ENVIRONMENT_NAME=$(/opt/elasticbeanstalk/bin/get-config container | jq .environment_name)
+export EB_APP_VERSION=$(jq '.RuntimeSources."eb-calisphere" | keys[0]' /opt/elasticbeanstalk/deployment/app_version_manifest.json)

--- a/public_interface/settings.py
+++ b/public_interface/settings.py
@@ -16,7 +16,7 @@ import os
 import sys
 
 # don't initialize Sentry if we're in a local dev environment
-if not bool(os.environ.get('UCLDC_DEBUG')):
+if bool(os.environ.get('EB_ENVIRONMENT_NAME')):
     import sentry_sdk
 
     # https://docs.sentry.io/platforms/python/integrations/django/

--- a/public_interface/settings.py
+++ b/public_interface/settings.py
@@ -27,7 +27,7 @@ if os.environ.get('UCLDC_FRONT') == 'https://calisphere.org/':
         # Set profiles_sample_rate to 1.0 to profile 100%
         # of sampled transactions.
         # We recommend adjusting this value in production.
-        profiles_sample_rate=1.0,
+        profiles_sample_rate=0.5,
     )
 
 def getenv(variable, default):

--- a/public_interface/settings.py
+++ b/public_interface/settings.py
@@ -24,11 +24,7 @@ if not bool(os.environ.get('UCLDC_DEBUG')):
         dsn="https://31e2ccf069b4049859fb97c8784ba33c@o1065376.ingest.us.sentry.io/4507346951274496",
         # Set traces_sample_rate to 1.0 to capture 100%
         # of transactions for performance monitoring.
-        traces_sample_rate=1.0,
-        # Set profiles_sample_rate to 1.0 to profile 100%
-        # of sampled transactions.
-        # We recommend adjusting this value in production.
-        profiles_sample_rate=0.5,
+        traces_sample_rate=0.2,
     )
 
 def getenv(variable, default):

--- a/public_interface/settings.py
+++ b/public_interface/settings.py
@@ -22,6 +22,9 @@ if not bool(os.environ.get('UCLDC_DEBUG')):
     # https://docs.sentry.io/platforms/python/integrations/django/
     sentry_sdk.init(
         dsn="https://31e2ccf069b4049859fb97c8784ba33c@o1065376.ingest.us.sentry.io/4507346951274496",
+        environment=os.environ.get('EB_ENVIRONMENT_NAME'),
+        release = os.environ.get('EB_APP_VERSION'),
+
         # Set traces_sample_rate to 1.0 to capture 100%
         # of transactions for performance monitoring.
         traces_sample_rate=0.2,

--- a/public_interface/settings.py
+++ b/public_interface/settings.py
@@ -15,19 +15,20 @@ from django.utils.crypto import get_random_string  # http://stackoverflow.com/a/
 import os
 import sys
 
-import sentry_sdk
+if os.environ.get('UCLDC_FRONT') == 'https://calisphere.org/':
+    import sentry_sdk
 
-# https://docs.sentry.io/platforms/python/integrations/django/
-sentry_sdk.init(
-    dsn="https://31e2ccf069b4049859fb97c8784ba33c@o1065376.ingest.us.sentry.io/4507346951274496",
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
-    # Set profiles_sample_rate to 1.0 to profile 100%
-    # of sampled transactions.
-    # We recommend adjusting this value in production.
-    profiles_sample_rate=1.0,
-)
+    # https://docs.sentry.io/platforms/python/integrations/django/
+    sentry_sdk.init(
+        dsn="https://31e2ccf069b4049859fb97c8784ba33c@o1065376.ingest.us.sentry.io/4507346951274496",
+        # Set traces_sample_rate to 1.0 to capture 100%
+        # of transactions for performance monitoring.
+        traces_sample_rate=1.0,
+        # Set profiles_sample_rate to 1.0 to profile 100%
+        # of sampled transactions.
+        # We recommend adjusting this value in production.
+        profiles_sample_rate=1.0,
+    )
 
 def getenv(variable, default):
     ''' getenv wrapper that decodes the same as python 3 in python 2

--- a/public_interface/settings.py
+++ b/public_interface/settings.py
@@ -15,7 +15,8 @@ from django.utils.crypto import get_random_string  # http://stackoverflow.com/a/
 import os
 import sys
 
-if os.environ.get('UCLDC_FRONT') == 'https://calisphere.org/':
+# don't initialize Sentry if we're in a local dev environment
+if not bool(os.environ.get('UCLDC_DEBUG')):
     import sentry_sdk
 
     # https://docs.sentry.io/platforms/python/integrations/django/

--- a/public_interface/settings.py
+++ b/public_interface/settings.py
@@ -15,6 +15,19 @@ from django.utils.crypto import get_random_string  # http://stackoverflow.com/a/
 import os
 import sys
 
+import sentry_sdk
+
+# https://docs.sentry.io/platforms/python/integrations/django/
+sentry_sdk.init(
+    dsn="https://31e2ccf069b4049859fb97c8784ba33c@o1065376.ingest.us.sentry.io/4507346951274496",
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    traces_sample_rate=1.0,
+    # Set profiles_sample_rate to 1.0 to profile 100%
+    # of sampled transactions.
+    # We recommend adjusting this value in production.
+    profiles_sample_rate=1.0,
+)
 
 def getenv(variable, default):
     ''' getenv wrapper that decodes the same as python 3 in python 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,3 @@ django-permissions-policy==4.19.0   # current
 elasticsearch==7.13.4               # 8.13.0 is current
 mysqlclient==2.0.1                  # current is 2.2.4
 sentry-sdk[django]==2.5.1           # current
-boto3==1.34.123                     # current
-python-magic-bin==0.4.14            # current
-pillow==10.3.0                      # current
-markdown==3.6                       # current

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,8 @@ django-recaptcha2==1.4.1            # current
 django-permissions-policy==4.19.0   # current
 elasticsearch==7.13.4               # 8.13.0 is current
 mysqlclient==2.0.1                  # current is 2.2.4
+sentry-sdk[django]==2.5.1           # current
+boto3==1.34.123                     # current
+python-magic-bin==0.4.14            # current
+pillow==10.3.0                      # current
+markdown==3.6                       # current


### PR DESCRIPTION
This PR adds the sentry.io Django integration to the codebase. I followed these instructions: https://docs.sentry.io/platforms/python/integrations/django/

I was able to send a test 500 error from my local instance of public_interface to Sentry: https://california-digital-library.sentry.io/issues/5475120042/?project=4507346951274496 to verify that it works.

~~Right now, I've left the `traces_sample_rate` and `profiles_sample_rate` at 1.0, which means 100% profiling of sampled transactions (whatever that means, exactly). They recommend adjusting this for production. I figured we can try out Sentry on calisphere-stage and then adjust before deploying to prod?~~

I also added `sentry-sdk[django]` to `requirements.txt`.

~~When running `pip install -r requirements.txt` in a brand new venv, I found that I need to install boto3, magic, pillow and markdown as well. Not sure if there was some reason those were not added before? @amywieliczka I know there is some funkiness with exhibits requirements.txt vs public_interface requirements.txt.~~