### PR TITLE
Revert to previous sentry dsn url, which was apparently correct

### DIFF
--- a/public_interface/settings.py
+++ b/public_interface/settings.py
@@ -21,7 +21,7 @@ if bool(os.environ.get('EB_ENVIRONMENT_NAME')):
 
     # https://docs.sentry.io/platforms/python/integrations/django/
     sentry_sdk.init(
-        dsn="https://b64d9cc32ed1c798d51995829b4e17d0@o1065376.ingest.us.sentry.io/4507346951274496",
+        dsn="https://31e2ccf069b4049859fb97c8784ba33c@o1065376.ingest.us.sentry.io/4507346951274496",
         environment=os.environ.get('EB_ENVIRONMENT_NAME'),
         release = os.environ.get('EB_APP_VERSION'),
 


### PR DESCRIPTION
The Sentry UI suggests 2 different DSN URL values, depending on where I look in the UI. I incorrectly assumed I had copied pub-janeway's url when I saw the alternate value:

https://b64d9cc32ed1c798d51995829b4e17d0@o1065376.ingest.us.sentry.io/4507346951274496

I see this value on this page in the code example when I'm logged into https://california-digital-library.sentry.io: 

https://docs.sentry.io/platforms/python/integrations/django/

However, when I go to  [Project] > Settings > Client Keys (DSN), I see the original value, which I'm reverting to here.