### PR TITLE
Stage

### DIFF
--- a/calisphere/facet_filter_type.py
+++ b/calisphere/facet_filter_type.py
@@ -212,13 +212,13 @@ class DecadeFF(FacetFilterType):
 
 class ESDecadeFF(ESFacetFilterType):
     form_name = 'facet_decade'
-    facet_field = 'date'
+    facet_field = 'facet_decade'
     #display_name = 'Decade'
     # see https://github.com/ucldc/rikolti/issues/807
-    display_name = 'Date'
-    filter_field = 'date.raw'
+    display_name = 'Decade'
+    filter_field = 'facet_decade.raw'
     sort_by = 'value'
-    none_date_label = "date information not supplied"
+    none_date_label = "decade information not supplied"
 
     def facet_transform(self, facet_val):
         if facet_val == '':


### PR DESCRIPTION
Includes:
- swap the date facet for the decade facet. 

At this time, 1,417 of 2,542 published collections were ETL'ed from Solr and so have `facet_decade` values in the index. We've determined that it's better to surface the Decade Facet for these 1,417 collections (and fail to surface any records with date values in the remaining 1,125 collections), than it is to surface a less useful Date Facet for all 2,542 collections. Simultaneously, we're working to add the appropriate enrichments to the harvesting pipeline to calculate a facet decade as part of the harvesting process. See https://github.com/ucldc/rikolti/issues/197 